### PR TITLE
Parser updates to support KGE predicate and relation properties

### DIFF
--- a/Common/test_common.py
+++ b/Common/test_common.py
@@ -14,7 +14,7 @@ def test_get_uniprot_virus_date_stamp():
 
     date_stamp: str = gd.get_uniprot_virus_date_stamp(data_file_path)
 
-    assert(date_stamp == '20200617')
+    assert(date_stamp == '20201007')
 
 
 def test_pull_via_http():
@@ -42,7 +42,7 @@ def test_get_taxon_id_list():
 
     taxonid_set: set = gd.get_ncbi_taxon_id_set(data_file_path, type_virus)
 
-    assert(len(taxonid_set) == 189019)
+    assert(len(taxonid_set) == 190167)
 
 
 def test_get_virus_files():
@@ -54,11 +54,11 @@ def test_get_virus_files():
 
     taxonid_set: set = gd.get_ncbi_taxon_id_set(data_file_path, type_virus)
 
-    assert(len(taxonid_set) == 189019)
+    assert(len(taxonid_set) == 190167)
 
     file_list: list = gd.get_uniprot_virus_file_list(data_file_path, taxonid_set)
 
-    assert(len(file_list) == 3993)
+    assert(len(file_list) == 3943)
 
 
 def test_get_goa_files_chain():
@@ -70,11 +70,11 @@ def test_get_goa_files_chain():
 
     taxonid_set: set = gd.get_ncbi_taxon_id_set(data_file_path, type_virus)
 
-    assert(len(taxonid_set) == 189019)
+    assert(len(taxonid_set) == 190167)
 
     file_list: list = gd.get_uniprot_virus_file_list(data_file_path, taxonid_set)
 
-    assert(len(file_list) == 3993)
+    assert(len(file_list) == 3943)
 
     data_file_path += '/Virus_GOA_files/'
 
@@ -93,18 +93,18 @@ def test_edge_norm():
     en = EdgeNormUtils()
 
     # create an edge list
-    edge_list: list = [{'predicate': 'SEMMEDDB:CAUSES', 'relation': '', 'edge_label': ''}, {'predicate': 'RO:0000052', 'relation': '', 'edge_label': ''}]
+    edge_list: list = [{'predicate': '', 'relation': 'SEMMEDDB:CAUSES', 'edge_label': ''}, {'predicate': '', 'relation': 'RO:0000052', 'edge_label': ''}]
 
     # normalize the data
     en.normalize_edge_data(edge_list)
 
     # check the return
-    assert(edge_list[0]['predicate'] == 'SEMMEDDB:CAUSES')
-    assert(edge_list[0]['relation'] == 'biolink:causes')
+    assert(edge_list[0]['predicate'] == 'biolink:causes')
+    assert(edge_list[0]['relation'] == 'SEMMEDDB:CAUSES')
     assert(edge_list[0]['edge_label'] == 'causes')
 
-    assert(edge_list[1]['predicate'] == 'RO:0000052')
-    assert(edge_list[1]['relation'] == 'biolink:affects')
+    assert(edge_list[1]['predicate'] == 'biolink:affects')
+    assert(edge_list[1]['relation'] == 'RO:0000052')
     assert(edge_list[1]['edge_label'] == 'affects')
 
 def test_get_node_synonym():

--- a/FooDB/src/loadFDB.py
+++ b/FooDB/src/loadFDB.py
@@ -65,7 +65,7 @@ class FDBLoader:
                 out_edge_f.write('{"edges":[\n')
             else:
                 out_node_f.write(f'id\tname\tcategory\tequivalent_identifiers\tfoodb_id\tcontent_type\tnutrient\n')
-                out_edge_f.write(f'id\tsubject\trelation\tedge_label\tobject\tunit\tamount\tsource_database\n')
+                out_edge_f.write(f'id\tpredicate\tsubject\trelation\tedge_label\tobject\tunit\tamount\tsource_database\n')
 
             # parse the data
             self.parse_data_file(data_file_path, out_node_f, out_edge_f, output_mode)
@@ -365,7 +365,7 @@ class FDBLoader:
                 for row in rows.iterrows():
                     # save the node id for the edges
                     if row[1].node_num != 1:
-                        edge_list.append({"predicate": "RO:0001019", "subject": f"{node_1_id}", "relation": "", "object": f"{row[1]['id']}", "edge_label": "biolink:related_to", "unit": f"{row[1]['unit']}", "amount": f"{row[1]['amount']}"})
+                        edge_list.append({"predicate": "", "subject": f"{node_1_id}", "relation": "RO:0001019", "object": f"{row[1]['id']}", "edge_label": "biolink:related_to", "unit": f"{row[1]['unit']}", "amount": f"{row[1]['amount']}"})
 
         # get a reference to the edge normalizer
         en = EdgeNormUtils(self.logger.level)
@@ -379,9 +379,9 @@ class FDBLoader:
 
             # depending on the output mode, create the KGX edge data for nodes 1 and 3
             if output_mode == 'json':
-                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "unit":"{item["unit"]}", "amount":"{item["amount"]}", "source_database":"FooDB"}}')
+                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "predicate":"{item["predicate"]}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "unit":"{item["unit"]}", "amount":"{item["amount"]}", "source_database":"FooDB"}}')
             else:
-                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\t{item["unit"]}\t{item["amount"]}\tFooDB')
+                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["predicate"]}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\t{item["unit"]}\t{item["amount"]}\tFooDB')
 
         self.logger.debug(f'{len(edge_set)} unique edges identified.')
 

--- a/GOA/src/loadGOA.py
+++ b/GOA/src/loadGOA.py
@@ -102,7 +102,7 @@ class GOALoader:
                     out_edge_f.write('{"edges":[\n')
                 else:
                     out_node_f.write(f'id\tname\tcategory\tequivalent_identifiers\n')
-                    out_edge_f.write(f'id\tsubject\trelation\tedge_label\tobject\tsource_database\n')
+                    out_edge_f.write(f'id\tpredicate\tsubject\trelation\tedge_label\tobject\tsource_database\n')
 
                 # parse the data
                 self.parse_data_file(os.path.join(data_file_path, data_file_name), out_node_f, out_edge_f, output_mode, swiss_prots)
@@ -259,18 +259,18 @@ class GOALoader:
 
             # find the predicate and edge relationships
             if node_3_type.find('molecular_activity') > -1:
-                predicate = 'RO:0002333'
-                relation = 'biolink:enabled_by'
+                predicate = 'biolink:enabled_by'
+                relation = 'RO:0002333'
                 src_node_id = node_3_id
                 obj_node_id = node_1_id
             elif node_3_type.find('biological_process') > -1:
-                predicate = 'RO:0002331'
-                relation = 'biolink:actively_involved_in'
+                predicate = 'biolink:actively_involved_in'
+                relation = 'RO:0002331'
                 src_node_id = node_1_id
                 obj_node_id = node_3_id
             elif node_3_type.find('cellular_component') > -1:
-                predicate = 'RO:0000051'
-                relation = 'biolink:has_part'
+                predicate = 'biolink:has_part'
+                relation = 'RO:0000051'
                 src_node_id = node_3_id
                 obj_node_id = node_1_id
             else:
@@ -293,9 +293,9 @@ class GOALoader:
 
             # depending on the output mode, create the KGX edge data for nodes 1 and 3
             if output_mode == 'json':
-                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"GOA_EBI-Human"}}')
+                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "predicate": "{item["predicate"]}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"GOA_EBI-Human"}}')
             else:
-                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\tGOA_EBI-Human')
+                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["predicate"]}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\tGOA_EBI-Human')
 
             self.logger.debug(f'{len(edge_set)} unique edges identified.')
 

--- a/IntAct/src/loadIA.py
+++ b/IntAct/src/loadIA.py
@@ -132,7 +132,7 @@ class IALoader:
                     out_edge_f.write('{"edges":[\n')
                 else:
                     out_node_f.write(f'id\tname\tcategory\tequivalent_identifiers\ttaxon\n')
-                    out_edge_f.write(f'id\tsubject\trelation\tedge_label\tpublications\tdetection_method\tobject\tsource_database\n')
+                    out_edge_f.write(f'id\tpredicate\tsubject\trelation\tedge_label\tpublications\tdetection_method\tobject\tsource_database\n')
 
                 # parse the data
                 self.parse_data_file(data_file_path, data_file_name, out_node_f, out_edge_f, output_mode, test_mode)
@@ -619,12 +619,12 @@ class IALoader:
                     self.logger.error(f"Publication ID missing for edge. Source: {grp_list[grp_idx]['u_a']}, Object: {grp_list[grp_idx]['u_b']}")
 
                 # add the interacting node edges
-                edge_list.append({"predicate": "RO:0002436", "subject": f"{grp_list[grp_idx]['u_a']}", "relation": "biolink:directly_interacts_with", "object": f"{grp_list[grp_idx]['u_b']}", "edge_label": "directly_interacts_with", "publications": f"{grp_list[grp_idx]['pub_id']}", "detection_method": detection_method})
+                edge_list.append({"predicate": "biolink:directly_interacts_with", "subject": f"{grp_list[grp_idx]['u_a']}", "relation": "RO:0002436", "object": f"{grp_list[grp_idx]['u_b']}", "edge_label": "directly_interacts_with", "publications": f"{grp_list[grp_idx]['pub_id']}", "detection_method": detection_method})
 
                 # for each type
                 for suffix in ['a', 'b']:
                     # add the taxa edges
-                    edge_list.append({"predicate": "RO:0002162", "subject": f"{grp_list[grp_idx]['u_' + suffix]}", "relation": "biolink:in_taxon", "object": f"{grp_list[grp_idx]['t_' + suffix]}", "edge_label": "in_taxon"})
+                    edge_list.append({"predicate": "biolink:in_taxon", "subject": f"{grp_list[grp_idx]['u_' + suffix]}", "relation": "RO:0002162", "object": f"{grp_list[grp_idx]['t_' + suffix]}", "edge_label": "in_taxon"})
 
                 # goto the next pair
                 grp_idx += 1
@@ -648,21 +648,21 @@ class IALoader:
             record_id: str = item["subject"] + item["relation"] + item["edge_label"] + item["object"]
 
             # if this is for the "directly interacts with" relationship
-            if item["predicate"] == 'RO:0002436':
+            if item["relation"] == 'RO:0002436':
                 # depending on the mode write out the uniprot A to uniprot B edge
                 if output_mode == 'json':
                     # get the detection methods into a list
                     detection_method: list = item['detection_method'].split('|')
 
-                    edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "publications":"{item["publications"]}", "detection_method":{json.dumps(list(detection_method))}, "source_database":"IntAct"}}')
+                    edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "predicate":"{item["predicate"]}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "publications":"{item["publications"]}", "detection_method":{json.dumps(list(detection_method))}, "source_database":"IntAct"}}')
                 else:
-                    edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["publications"]}\t{item["detection_method"]}\t{item["object"]}\tIntAct')
+                    edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["predicate"]}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["publications"]}\t{item["detection_method"]}\t{item["object"]}\tIntAct')
             else:
                 # depending on the output mode write out the uniprot to NCBI taxon edge
                 if output_mode == 'json':
-                    edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"IntAct"}}')
+                    edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "predicate":"{item["predicate"]}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"IntAct"}}')
                 else:
-                    edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t\t\t{item["object"]}\tIntAct')
+                    edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["predicate"]}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t\t\t{item["object"]}\tIntAct')
 
         # write out the edge data
         if output_mode == 'json':

--- a/PHAROS/src/loadPHAROS.py
+++ b/PHAROS/src/loadPHAROS.py
@@ -108,7 +108,7 @@ class PHAROSLoader:
         """
 
         # create a logger
-        self.logger = LoggingUtil.init_logging("Data_services.FooDB.PHAROSLoader", level=log_level, line_format='medium', log_file_path=os.path.join(Path(__file__).parents[2], 'logs'))
+        self.logger = LoggingUtil.init_logging("Data_services.PHAROSLoader", level=log_level, line_format='medium', log_file_path=os.path.join(Path(__file__).parents[2], 'logs'))
 
         # get a connection to the PHAROS MySQL DB
         self.db = mysql.connector.connect(host="localhost", user="root", password='TSZTVhsjmoAi9MH1n1jo', database="pharos67")
@@ -132,7 +132,7 @@ class PHAROSLoader:
                 out_edge_f.write('{"edges":[\n')
             else:
                 out_node_f.write(f'id\tname\tcategory\tequivalent_identifiers\n')
-                out_edge_f.write(f'id\tsubject\trelation\tedge_label\tobject\tpublications\taffinity\taffinity_parameter\tprovenance\tsource_database\n')
+                out_edge_f.write(f'id\tpredicate\tsubject\trelation\tedge_label\tobject\tpublications\taffinity\taffinity_parameter\tprovenance\tsource_database\n')
 
             # parse the data
             self.parse_data_db(out_node_f, out_edge_f, output_mode)
@@ -277,7 +277,7 @@ class PHAROSLoader:
                 node_list.append({'grp': grp, 'node_num': 1, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': ''})
 
                 # create the disease node and add it to the list
-                node_list.append({'grp': grp, 'node_num': 2, 'id': did, 'name': name, 'category': '', 'equivalent_identifiers': '', 'predicate': 'WD:P2293', 'relation': 'WD:P2293', 'edge_label': 'gene_involved', 'pmids': [], 'affinity': 0, 'affinity_parameter': '', 'provenance': provenance})
+                node_list.append({'grp': grp, 'node_num': 2, 'id': did, 'name': name, 'category': '', 'equivalent_identifiers': '', 'predicate': 'biolink:gene_associated_with_condition', 'relation': 'WD:P2293', 'edge_label': 'gene_involved', 'pmids': [], 'affinity': 0, 'affinity_parameter': '', 'provenance': provenance})
 
         # return the node list to the caller
         return node_list
@@ -300,7 +300,7 @@ class PHAROSLoader:
             gene = item['value']
             gene_sym = item['sym']
             chembl_id = f"{prefixmap[item['id_src']]}:{item['cid']}"
-            predicate, pmids, props, provenance = self.get_edge_props(item)
+            relation, pmids, props, provenance = self.get_edge_props(item)
 
             # if there were affinity properties use them
             if len(props) == 2:
@@ -311,14 +311,14 @@ class PHAROSLoader:
                 affinity_parameter = ''
 
             # create the group id
-            grp: str = chembl_id + predicate + gene + f'{random.random()}'
+            grp: str = chembl_id + relation + gene + f'{random.random()}'
             grp = hashlib.md5(grp.encode("utf-8")).hexdigest()
 
             # create the disease node and add it to the node list
             node_list.append({'grp': grp, 'node_num': 1, 'id': chembl_id, 'name': name, 'category': '', 'equivalent_identifiers': ''})
 
             # create the gene node and add it to the list
-            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': predicate, 'relation': '', 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
+            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': '', 'relation': relation, 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
         return node_list
 
     def parse_gene_to_cmpd_activity(self, node_list: list) -> list:
@@ -338,7 +338,7 @@ class PHAROSLoader:
             gene = item['value']
             gene_sym = item['sym']
             chembl_id = f"{prefixmap[item['id_src']]}:{item['cid']}"
-            predicate, pmids, props, provenance = self.get_edge_props(item)
+            relation, pmids, props, provenance = self.get_edge_props(item)
 
             # if there were affinity properties use them
             if len(props) == 2:
@@ -349,14 +349,14 @@ class PHAROSLoader:
                 affinity_parameter = ''
 
             # create the group id
-            grp: str = chembl_id + predicate + gene + f'{random.random()}'
+            grp: str = chembl_id + relation + gene + f'{random.random()}'
             grp = hashlib.md5(grp.encode("utf-8")).hexdigest()
 
             # create the disease node and add it to the node list
             node_list.append({'grp': grp, 'node_num': 1, 'id': chembl_id, 'name': name, 'category': '', 'equivalent_identifiers': ''})
 
             # create the gene node and add it to the list
-            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': predicate, 'relation': '', 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
+            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': '', 'relation': relation, 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
 
         return node_list
 
@@ -378,7 +378,7 @@ class PHAROSLoader:
             gene = item['value']
             gene_sym = item['sym']
             chembl_id = 'CHEMBL.COMPOUND:' + item['cmpd_chemblid']
-            predicate, pmids, props, provenance = self.get_edge_props(item)
+            relation, pmids, props, provenance = self.get_edge_props(item)
 
             # if there were affinity properties use them
             if len(props) == 2:
@@ -389,14 +389,14 @@ class PHAROSLoader:
                 affinity_parameter = ''
 
             # create the group id
-            grp: str = chembl_id + predicate + gene + f'{random.random()}'
+            grp: str = chembl_id + relation + gene + f'{random.random()}'
             grp = hashlib.md5(grp.encode("utf-8")).hexdigest()
 
             # create the disease node and add it to the node list
             node_list.append({'grp': grp, 'node_num': 1, 'id': chembl_id, 'name': name, 'category': '', 'equivalent_identifiers': ''})
 
             # create the gene node and add it to the list
-            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': predicate, 'relation': '', 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
+            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': '', 'relation': relation, 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
 
         return node_list
 
@@ -416,7 +416,7 @@ class PHAROSLoader:
             gene = item['value']
             gene_sym = item['sym']
             chembl_id = 'CHEMBL.COMPOUND:' + item['drug']
-            predicate, pmids, props, provenance = self.get_edge_props(item)
+            relation, pmids, props, provenance = self.get_edge_props(item)
 
             # if there were affinity properties use them
             if len(props) == 2:
@@ -427,14 +427,14 @@ class PHAROSLoader:
                 affinity_parameter = ''
 
             # create the group id
-            grp: str = chembl_id + predicate + gene + f'{random.random()}'
+            grp: str = chembl_id + relation + gene + f'{random.random()}'
             grp = hashlib.md5(grp.encode("utf-8")).hexdigest()
 
             # create the disease node and add it to the node list
             node_list.append({'grp': grp, 'node_num': 1, 'id': chembl_id, 'name': name, 'category': '', 'equivalent_identifiers': ''})
 
             # create the gene node and add it to the list
-            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': predicate, 'relation': '', 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
+            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': '', 'relation': relation, 'edge_label': '', 'pmids': pmids, 'affinity': affinity, 'affinity_parameter': affinity_parameter, 'provenance': provenance})
 
         # return the node list to the caller
         return node_list
@@ -482,7 +482,7 @@ class PHAROSLoader:
             node_list.append({'grp': grp, 'node_num': 1, 'id': did, 'name': name, 'category': '', 'equivalent_identifiers': ''})
 
             # create the gene node and add it to the node list
-            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': 'WD:P2293', 'relation': 'WD:P2293', 'edge_label': 'gene_involved', 'pmids': [], 'affinity': 0, 'affinity_parameter': '', 'provenance': provenance})
+            node_list.append({'grp': grp, 'node_num': 2, 'id': gene, 'name': gene_sym, 'category': '', 'equivalent_identifiers': '', 'predicate': 'biolink:gene_associated_with_condition', 'relation': 'WD:P2293', 'edge_label': 'gene_involved', 'pmids': [], 'affinity': 0, 'affinity_parameter': '', 'provenance': provenance})
 
         return node_list
 
@@ -491,7 +491,7 @@ class PHAROSLoader:
         gets the edge properties from the node results
 
         :param result:
-        :return str: predicate, list: pmids, dict: props, str: provenance:
+        :return str: relation, list: pmids, dict: props, str: provenance:
         """
         # if there was a predicate make it look pretty
         if result['pred'] is not None and len(result['pred']) > 1:
@@ -499,8 +499,8 @@ class PHAROSLoader:
         else:
             rel: str = 'interacts_with'
 
-        # save the predicate
-        predicate: str = f'GAMMA:{rel}'
+        # save the relation
+        relation: str = f'GAMMA:{rel}'
 
         # if there was provenance data save it
         if result['dtype'] is not None:
@@ -528,7 +528,7 @@ class PHAROSLoader:
             props['affinity_parameter'] = ''
 
         # return to the caller
-        return predicate, pmids, props, provenance
+        return relation, pmids, props, provenance
 
     @staticmethod
     def snakify(text):
@@ -600,9 +600,11 @@ class PHAROSLoader:
                     for row in rows.iterrows():
                         # save the nodes and the node id for the edge
                         if row[1].node_num != 1:
-                            new_node_list.append(node_1)
-                            new_node_list.append(row[1])
-                            edge_list.append({"predicate": row[1]['predicate'], "subject": node_1_id, "relation": row[1]['relation'], "object": row[1]['id'], "edge_label": row[1]['edge_label'], "pmids": '|'.join(row[1]['pmids']), "affinity": row[1]['affinity'], "affinity_parameter":  row[1]['affinity_parameter'], 'provenance': row[1]['provenance']})
+                            # only create the edge/nodes if the edge normalized properly
+                            if row[1]['predicate'] != '' and row[1]['edge_label'] != '':
+                                new_node_list.append(node_1)
+                                new_node_list.append(row[1])
+                                edge_list.append({"predicate": row[1]['predicate'], "subject": node_1_id, "relation": row[1]['relation'], "object": row[1]['id'], "edge_label": row[1]['edge_label'], "pmids": '|'.join(row[1]['pmids']), "affinity": row[1]['affinity'], "affinity_parameter":  row[1]['affinity_parameter'], 'provenance': row[1]['provenance']})
             else:
                 self.logger.debug(f'node group mismatch. len: {len(rows)}, data: {rows}')
 
@@ -624,9 +626,9 @@ class PHAROSLoader:
                     # get the pubmed ids into a text json format
                     pmids: str = json.dumps(item["pmids"].split('|'))
 
-                    edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "publications": {pmids}, "affinity": {item["affinity"]}, "affinity_parameter": "{item["affinity_parameter"]}", "provenance": "{item["provenance"]}", "source_database":"PHAROS 6.7"}}')
+                    edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "predicate":"{item["predicate"]}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "publications": {pmids}, "affinity": {item["affinity"]}, "affinity_parameter": "{item["affinity_parameter"]}", "provenance": "{item["provenance"]}", "source_database":"PHAROS 6.7"}}')
                 else:
-                    edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\t{item["pmids"]}\t{item["affinity"]}\t{item["affinity_parameter"]}\t{item["provenance"]}\tPHAROS 6.7')
+                    edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["predicate"]}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\t{item["pmids"]}\t{item["affinity"]}\t{item["affinity_parameter"]}\t{item["provenance"]}\tPHAROS 6.7')
 
         self.logger.debug(f'{len(edge_set)} unique edges identified.')
 

--- a/UberGraph/src/loadUG.py
+++ b/UberGraph/src/loadUG.py
@@ -87,7 +87,7 @@ class UGLoader:
                     out_edge_f.write('{"edges":[\n')
                 else:
                     out_node_f.write(f'id\tname\tcategory\tequivalent_identifiers\n')
-                    out_edge_f.write(f'id\tsubject\trelation\tedge_label\tobject\tsource_database\n')
+                    out_edge_f.write(f'id\tpredicate\tsubject\trelation\tedge_label\tobject\tsource_database\n')
 
                 self.logger.info(f'Splitting UberGraph data file: {file_name}. {file_size} records per file + remainder')
 
@@ -351,9 +351,10 @@ class UGLoader:
             source_node: dict = {}
             object_node: dict = {}
 
-            # get the edge relation and edge label using the group name
+            # get the predicate, relation and label using the group name
             edge_relation = df_edges.loc[cur_grp_name].relation
             edge_label = df_edges.loc[cur_grp_name].edge_label
+            edge_predicate = df_edges.loc[cur_grp_name].predicate
 
             # now that we have a group create the edges
             while grp_idx < len(grp_list):
@@ -380,9 +381,9 @@ class UGLoader:
 
                 # write out the edge
                 if output_mode == 'json':
-                    self.final_edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}","subject":"{source_node["id"]}","relation":"{edge_relation}","object":"{object_node["id"]}","edge_label":"{edge_label}","source_database":"{data_source_name}"}}')
+                    self.final_edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}","predicate":"{edge_predicate}","subject":"{source_node["id"]}","relation":"{edge_relation}","object":"{object_node["id"]}","edge_label":"{edge_label}","source_database":"{data_source_name}"}}')
                 else:
-                    self.final_edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{source_node["id"]}\t{edge_relation}\t{edge_relation}\t{object_node["id"]}\t{data_source_name}')
+                    self.final_edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{edge_predicate}\t{source_node["id"]}\t{edge_relation}\t{edge_label}\t{object_node["id"]}\t{data_source_name}')
 
                 # increment the edge count
                 self.total_edges += 1

--- a/UberGraph/src/loadUG.py
+++ b/UberGraph/src/loadUG.py
@@ -351,8 +351,9 @@ class UGLoader:
             source_node: dict = {}
             object_node: dict = {}
 
-            # get the edge relation using the group name
+            # get the edge relation and edge label using the group name
             edge_relation = df_edges.loc[cur_grp_name].relation
+            edge_label = df_edges.loc[cur_grp_name].edge_label
 
             # now that we have a group create the edges
             while grp_idx < len(grp_list):
@@ -379,7 +380,7 @@ class UGLoader:
 
                 # write out the edge
                 if output_mode == 'json':
-                    self.final_edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}","subject":"{source_node["id"]}","relation":"{edge_relation}","object":"{object_node["id"]}","edge_label":"{edge_relation}","source_database":"{data_source_name}"}}')
+                    self.final_edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}","subject":"{source_node["id"]}","relation":"{edge_relation}","object":"{object_node["id"]}","edge_label":"{edge_label}","source_database":"{data_source_name}"}}')
                 else:
                     self.final_edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{source_node["id"]}\t{edge_relation}\t{edge_relation}\t{object_node["id"]}\t{data_source_name}')
 

--- a/ViralProteome/src/loadUniRef.py
+++ b/ViralProteome/src/loadUniRef.py
@@ -558,7 +558,7 @@ class UniRefSimLoader:
                     similarity_bin = node_list[node_idx]['similarity_bin']
                 # get the UniRef entry common taxon ID and create the UniRef ID to taxon edge
                 elif node_list[node_idx]['node_num'] == 1 and gene_family_node_id != '':
-                    edge_list.append({"predicate": "RO:0002162", "subject": f"{gene_family_node_id}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx]['id']}", "edge_label": "", "source_database": f"{gene_family_node_id.split(':')[0]}"})
+                    edge_list.append({"predicate": "RO:0002162", "subject": f"{gene_family_node_id}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx]['id']}", "edge_label": "in_taxon", "source_database": f"{gene_family_node_id.split(':')[0]}"})
                 # get the member node edges
                 elif similarity_bin != '' and gene_family_node_id != '':
                     edge_list.append({"predicate": "BFO:0000050", "subject": f"{node_list[node_idx]['id']}", "relation": "biolink:part_of", "object": f"{gene_family_node_id}", "edge_label": "part_of", "source_database": f"{node_list[node_idx]['id'].split(':')[0]}"})
@@ -570,7 +570,7 @@ class UniRefSimLoader:
 
                     # add the spoke edge if it isn't a reflection of itself
                     if rep_member_node_id != node_list[node_idx]['id']:
-                        edge_list.append({"predicate": f"{similarity_bin}", "subject": f"{rep_member_node_id}", "relation": f"{similarity_bin}", "object": f"{node_list[node_idx]['id']}", "edge_label": "SO:similar_to", "source_database": f"{rep_member_node_id.split(':')[0]}"})
+                        edge_list.append({"predicate": "RO:HOM0000000", "subject": f"{rep_member_node_id}", "relation": "biolink:similar_to", "object": f"{node_list[node_idx]['id']}", "edge_label": f"{similarity_bin}", "source_database": f"{rep_member_node_id.split(':')[0]}"})
 
                     # increment the node counter pairing
                     node_idx += 1

--- a/ViralProteome/src/loadUniRef.py
+++ b/ViralProteome/src/loadUniRef.py
@@ -85,7 +85,7 @@ class UniRefSimLoader:
                     out_edge_f.write('{"edges":[\n')
                 else:
                     out_node_f.write(f'id\tname\tcategory\tequivalent_identifiers\n')
-                    out_edge_f.write(f'id\tsubject\trelation\tedge_label\tobject\tsource_database\n')
+                    out_edge_f.write(f'id\tpredicate\tsubject\trelation\tedge_label\tobject\tsource_database\n')
 
                 # add the file extension
                 if test_mode:
@@ -558,11 +558,11 @@ class UniRefSimLoader:
                     similarity_bin = node_list[node_idx]['similarity_bin']
                 # get the UniRef entry common taxon ID and create the UniRef ID to taxon edge
                 elif node_list[node_idx]['node_num'] == 1 and gene_family_node_id != '':
-                    edge_list.append({"predicate": "RO:0002162", "subject": f"{gene_family_node_id}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx]['id']}", "edge_label": "in_taxon", "source_database": f"{similarity_bin}"})
+                    edge_list.append({"predicate": "biolink:in_taxon", "subject": f"{gene_family_node_id}", "relation": "RO:0002162", "object": f"{node_list[node_idx]['id']}", "edge_label": "in_taxon", "source_database": f"{similarity_bin}"})
                 # get the member node edges
                 elif similarity_bin != '' and gene_family_node_id != '':
-                    edge_list.append({"predicate": "BFO:0000050", "subject": f"{node_list[node_idx]['id']}", "relation": "biolink:part_of", "object": f"{gene_family_node_id}", "edge_label": "part_of", "source_database": f"{similarity_bin}"})
-                    edge_list.append({"predicate": "RO:0002162", "subject": f"{node_list[node_idx]['id']}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx + 1]['id']}", "edge_label": "in_taxon", "source_database": f"{similarity_bin}"})
+                    edge_list.append({"predicate": "biolink:part_of", "subject": f"{node_list[node_idx]['id']}", "relation": "BFO:0000050", "object": f"{gene_family_node_id}", "edge_label": "part_of", "source_database": f"{similarity_bin}"})
+                    edge_list.append({"predicate": "biolink:in_taxon", "subject": f"{node_list[node_idx]['id']}", "relation": "RO:0002162", "object": f"{node_list[node_idx + 1]['id']}", "edge_label": "in_taxon", "source_database": f"{similarity_bin}"})
 
                     # this node is the representative UniProtKB ID node
                     if node_list[node_idx]['node_num'] == 2:
@@ -570,7 +570,7 @@ class UniRefSimLoader:
 
                     # add the spoke edge if it isn't a reflection of itself
                     if rep_member_node_id != node_list[node_idx]['id']:
-                        edge_list.append({"predicate": "RO:HOM0000000", "subject": f"{rep_member_node_id}", "relation": "biolink:similar_to", "object": f"{node_list[node_idx]['id']}", "edge_label": "similar_to", "source_database": f"{similarity_bin}"})
+                        edge_list.append({"predicate": "biolink:similar_to", "subject": f"{rep_member_node_id}", "relation": "RO:HOM0000000", "object": f"{node_list[node_idx]['id']}", "edge_label": "similar_to", "source_database": f"{similarity_bin}"})
 
                     # increment the node counter pairing
                     node_idx += 1
@@ -604,9 +604,9 @@ class UniRefSimLoader:
 
             # depending on the output mode save the edge data
             if output_mode == 'json':
-                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"{item["source_database"]}"}}')
+                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "predicate":"{item["predicate"]}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"{item["source_database"]}"}}')
             else:
-                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\t{item["source_database"]}')
+                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["predicate"]}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\t{item["source_database"]}')
 
         # write out the edge data
         if output_mode == 'json':

--- a/ViralProteome/src/loadUniRef.py
+++ b/ViralProteome/src/loadUniRef.py
@@ -558,11 +558,11 @@ class UniRefSimLoader:
                     similarity_bin = node_list[node_idx]['similarity_bin']
                 # get the UniRef entry common taxon ID and create the UniRef ID to taxon edge
                 elif node_list[node_idx]['node_num'] == 1 and gene_family_node_id != '':
-                    edge_list.append({"predicate": "RO:0002162", "subject": f"{gene_family_node_id}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx]['id']}", "edge_label": "in_taxon", "source_database": f"{gene_family_node_id.split(':')[0]}"})
+                    edge_list.append({"predicate": "RO:0002162", "subject": f"{gene_family_node_id}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx]['id']}", "edge_label": "in_taxon", "source_database": f"{similarity_bin}"})
                 # get the member node edges
                 elif similarity_bin != '' and gene_family_node_id != '':
-                    edge_list.append({"predicate": "BFO:0000050", "subject": f"{node_list[node_idx]['id']}", "relation": "biolink:part_of", "object": f"{gene_family_node_id}", "edge_label": "part_of", "source_database": f"{node_list[node_idx]['id'].split(':')[0]}"})
-                    edge_list.append({"predicate": "RO:0002162", "subject": f"{node_list[node_idx]['id']}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx + 1]['id']}", "edge_label": "in_taxon", "source_database": f"{node_list[node_idx]['id'].split(':')[0]}"})
+                    edge_list.append({"predicate": "BFO:0000050", "subject": f"{node_list[node_idx]['id']}", "relation": "biolink:part_of", "object": f"{gene_family_node_id}", "edge_label": "part_of", "source_database": f"{similarity_bin}"})
+                    edge_list.append({"predicate": "RO:0002162", "subject": f"{node_list[node_idx]['id']}", "relation": "biolink:in_taxon", "object": f"{node_list[node_idx + 1]['id']}", "edge_label": "in_taxon", "source_database": f"{similarity_bin}"})
 
                     # this node is the representative UniProtKB ID node
                     if node_list[node_idx]['node_num'] == 2:
@@ -570,7 +570,7 @@ class UniRefSimLoader:
 
                     # add the spoke edge if it isn't a reflection of itself
                     if rep_member_node_id != node_list[node_idx]['id']:
-                        edge_list.append({"predicate": "RO:HOM0000000", "subject": f"{rep_member_node_id}", "relation": "biolink:similar_to", "object": f"{node_list[node_idx]['id']}", "edge_label": f"{similarity_bin}", "source_database": f"{rep_member_node_id.split(':')[0]}"})
+                        edge_list.append({"predicate": "RO:HOM0000000", "subject": f"{rep_member_node_id}", "relation": "biolink:similar_to", "object": f"{node_list[node_idx]['id']}", "edge_label": "similar_to", "source_database": f"{similarity_bin}"})
 
                     # increment the node counter pairing
                     node_idx += 1

--- a/ViralProteome/src/loadVP.py
+++ b/ViralProteome/src/loadVP.py
@@ -114,7 +114,7 @@ class VPLoader:
                     out_edge_f.write('{"edges":[\n')
                 else:
                     out_node_f.write(f'id\tname\tcategory\tequivalent_identifiers\n')
-                    out_edge_f.write(f'id\tsubject\trelation\tedge_label\tobject\tsource_database\n')
+                    out_edge_f.write(f'id\tpredicate\tsubject\trelation\tedge_label\tobject\tsource_database\n')
 
                 # init a file counter
                 file_counter: int = 0
@@ -224,9 +224,9 @@ class VPLoader:
 
             # depending on the output mode save edge contents
             if output_mode == 'json':
-                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "subject":"{item["subject"]}", "relation":"RO:0002162", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"UniProtKB GOA Viral proteomes"}}')
+                edge_set.add(f'{{"id":"{hashlib.md5(record_id.encode("utf-8")).hexdigest()}", "predicate":"{item["predicate"]}", "subject":"{item["subject"]}", "relation":"{item["relation"]}", "object":"{item["object"]}", "edge_label":"{item["edge_label"]}", "source_database":"UniProtKB GOA Viral proteomes"}}')
             else:
-                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\tUniProtKB GOA Viral proteomes')
+                edge_set.add(f'{hashlib.md5(record_id.encode("utf-8")).hexdigest()}\t{item["predicate"]}\t{item["subject"]}\t{item["relation"]}\t{item["edge_label"]}\t{item["object"]}\tUniProtKB GOA Viral proteomes')
 
         # return the edge set to the caller
         return edge_set
@@ -291,7 +291,7 @@ class VPLoader:
             if node_1_id != '' and node_2_id != '':
                 # create the KGX edge data for nodes 1 and 2
                 """ An edge from the gene to the organism_taxon with relation "in_taxon" """
-                edge_list.append({"predicate": "RO:0002162", "subject": f"{node_1_id}", "relation": "biolink:in_taxon", "object": f"{node_2_id}", "edge_label": "in_taxon"})
+                edge_list.append({"predicate": "biolink:in_taxon", "subject": f"{node_1_id}", "relation": "RO:0002162", "object": f"{node_2_id}", "edge_label": "in_taxon"})
             else:
                 self.logger.warning(f'Warning: Missing 1 or more node IDs. Node type 1: {node_1_id}, Node type 2: {node_2_id}')
 
@@ -313,20 +313,20 @@ class VPLoader:
 
                 # find the predicate and edge relationships
                 if node_3_type.find('molecular_activity') > -1:
-                    predicate = 'RO:0002333'
-                    relation = 'biolink:enabled_by'
+                    predicate = 'biolink:enabled_by'
+                    relation = 'RO:0002333'
                     label = 'enabled_by'
                     src_node_id = node_3_id
                     obj_node_id = node_1_id
                 elif node_3_type.find('biological_process') > -1:
-                    predicate = 'RO:0002331'
-                    relation = 'biolink:actively_involved_in'
+                    predicate = 'biolink:actively_involved_in'
+                    relation = 'RO:0002331'
                     label = 'actively_involved_in'
                     src_node_id = node_1_id
                     obj_node_id = node_3_id
                 elif node_3_type.find('cellular_component') > -1:
-                    predicate = 'RO:0000051'
-                    relation = 'biolink:has_part'
+                    predicate = 'biolink:has_part'
+                    relation = 'RO:0000051'
                     label = 'has_part'
                     src_node_id = node_3_id
                     obj_node_id = node_1_id

--- a/ViralProteome/src/loadVP.py
+++ b/ViralProteome/src/loadVP.py
@@ -320,7 +320,7 @@ class VPLoader:
                     obj_node_id = node_1_id
                 elif node_3_type.find('biological_process') > -1:
                     predicate = 'RO:0002331'
-                    relation = 'actively_involved_in'
+                    relation = 'biolink:actively_involved_in'
                     label = 'actively_involved_in'
                     src_node_id = node_1_id
                     obj_node_id = node_3_id


### PR DESCRIPTION
This update:

- realigns the contents of the edge predicate and relation properties to conform to the latest KGE standards.
- removes the code that allowed the use of deprecated KGE predicate and relation edge property contents. 
- corrects output errors in VP and PHAROS data sets.
- updates test record count assertions as the latest versions of the data sets have been downloaded and processed.

Note there is one test that fails because the function get_node_synonyms() in the NodeNormalization class has not yet made its way to master.
