### PR TITLE
Fix incorrect ID mappings from PhysicalEntity/Event crossReferences

### DIFF
--- a/parsers/Reactome/src/loadReactome.py
+++ b/parsers/Reactome/src/loadReactome.py
@@ -264,12 +264,17 @@ class ReactomeLoader(SourceDataLoader):
  
     def get_reference_entity_mapping(self, neo4j_session):
         reference_entity_mapping = {}
-        # The following line excludes Pathways from ID mapping because we only want to map them to GO terms, like 2 lines below.
-        reference_entity_query = "MATCH (a)-[r:referenceEntity|crossReference]->(b) WHERE NOT('Pathway' in labels(a)) return id(a) as identity, b as reference, labels(b) as ref_labels"
+        # Split into two queries to avoid problematic PhysicalEntity/Event crossReferences
+        # Query 1: referenceEntity links (PhysicalEntity instances -> ReferenceEntity definitions)
+        reference_entity_query = "MATCH (a)-[r:referenceEntity]->(b) WHERE NOT('Pathway' in labels(a)) return id(a) as identity, b as reference, labels(b) as ref_labels"
+        # Query 2: crossReference links (ReferenceEntity -> External DBs), excluding PhysicalEntity/Event nodes
+        cross_reference_query = "MATCH (a)-[r:crossReference]->(b) WHERE NOT('Pathway' in labels(a)) AND NOT('PhysicalEntity' in labels(a)) AND NOT('Event' in labels(a)) return id(a) as identity, b as reference, labels(b) as ref_labels"
+        # Query 3: Pathway to GO term mappings
         goBioProcess_query = "MATCH (a:Pathway)-[r:goBiologicalProcess]->(b:GO_Term) WHERE replace(toLower(a.displayName),'-',' ') = replace(toLower(b.displayName),'-',' ') return id(a) as identity, b as reference, labels(b) as ref_labels"
         reference_entity_result = neo4j_session.run(reference_entity_query)
-        goBioProcess_query = neo4j_session.run(goBioProcess_query)
-        all_crossmap_id_results = [reference_entity_result, goBioProcess_query]
+        cross_reference_result = neo4j_session.run(cross_reference_query)
+        goBioProcess_result = neo4j_session.run(goBioProcess_query)
+        all_crossmap_id_results = [reference_entity_result, cross_reference_result, goBioProcess_result]
         for result_set in all_crossmap_id_results:
             for record in result_set:
                 record_data = record.data()


### PR DESCRIPTION
## Summary

This PR fixes incorrect ID mappings in the Reactome parser that were causing downstream errors. The reference entity mapping query was including crossReference relationships from PhysicalEntity and Event nodes, which created problematic mappings.

## Problem

The original query combined both `referenceEntity` and `crossReference` relationships in a single pattern:
```cypher
MATCH (a)-[r:referenceEntity|crossReference]->(b) WHERE NOT('Pathway' in labels(a))
```

This included problematic crossReferences like:
- `R-ALL-113541` (PPi SimpleEntity) → `COMPOUND:C00013` (KEGG)
- Reactions → Disease identifiers
- Other PhysicalEntity/Event instances → External databases

A total of 30,075 crossReference relationships had PhysicalEntity or Event nodes as the source.

## Solution

The key change is **excluding PhysicalEntity and Event nodes from crossReference relationships**. This is implemented by splitting into separate queries:

1. **referenceEntity query**: Unchanged - keeps all PhysicalEntity → ReferenceEntity links (242,637 relationships)

2. **crossReference query**: Now filters out PhysicalEntity and Event nodes
   ```cypher
   WHERE NOT('PhysicalEntity' in labels(a)) AND NOT('Event' in labels(a))
   ```
   - Only includes ReferenceEntity → External DB mappings
   - Example: `UniProt:P68104` → `ENSEMBL:ENSP00000503823`
   - Keeps 910,753 valid relationships, removes 30,075 problematic ones

3. **goBioProcess query**: Unchanged

## Impact

- Removes 30,075 incorrect crossReference mappings
- Preserves all valid referenceEntity and crossReference relationships
- Should eliminate downstream errors from these incorrect mappings

## Testing

Validated against live Reactome Neo4j database to confirm:
- PhysicalEntity and Event nodes excluded from crossReference results
- All referenceEntity relationships preserved
- Only ReferenceEntity → External DB crossReferences included