### PR TITLE
Merging and Metadata improvements

### DIFF
--- a/orion/build_manager.py
+++ b/orion/build_manager.py
@@ -569,6 +569,7 @@ class GraphBuilder:
                 graph_wide_strict_norm = graph_yaml.get('strict_normalization', None)
                 add_edge_id = graph_yaml.get('add_edge_id', None)
                 edge_id_type = graph_yaml.get('edge_id_type', None)
+                overwrite_edge_ids = graph_yaml.get('overwrite_edge_ids', True)
                 edge_merging_attributes = graph_yaml.get('edge_merging_attributes', None)
                 if graph_wide_conflation is not None and type(graph_wide_conflation) != bool:
                     raise GraphSpecError(f'Invalid type (conflation: {graph_wide_conflation}), must be true or false.')
@@ -578,6 +579,8 @@ class GraphBuilder:
                     raise GraphSpecError(f'Invalid type (add_edge_id: {add_edge_id}), must be true or false.')
                 if edge_id_type is not None and edge_id_type not in ('orion', 'uuid'):
                     raise GraphSpecError(f'Invalid edge_id_type: {edge_id_type}, must be "orion" or "uuid".')
+                if type(overwrite_edge_ids) != bool:
+                    raise GraphSpecError(f'Invalid type (overwrite_edge_ids: {overwrite_edge_ids}), must be true or false.')
                 if edge_id_type is not None and add_edge_id is None or add_edge_id is False:
                     add_edge_id = True
                 if graph_wide_node_norm_version == 'latest':
@@ -608,6 +611,7 @@ class GraphBuilder:
                                        graph_output_format=graph_output_format,
                                        add_edge_id=add_edge_id,
                                        edge_id_type=edge_id_type,
+                                       overwrite_edge_ids=overwrite_edge_ids,
                                        edge_merging_attributes=edge_merging_attributes,
                                        subgraphs=subgraph_sources,
                                        sources=data_sources)

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -89,12 +89,11 @@ class KGXFileMerger:
             self.merge_metadata['final_edge_count'] += merged_edges_written + unmerged_edges_written
             self.merge_metadata['merged_nodes'] += self.node_graph_merger.merged_node_counter
             self.merge_metadata['merged_edges'] += self.edge_graph_merger.merged_edge_counter
-            for entity_type, merger in (('nodes', self.node_graph_merger),
-                                        ('edges', self.edge_graph_merger)):
+            for merger in (self.node_graph_merger, self.edge_graph_merger):
                 for warning_type in ('mismatched_properties', 'dropped_properties'):
-                    existing = set(self.merge_metadata['merge_warnings'][entity_type][warning_type])
+                    existing = set(self.merge_metadata['merge_warnings'][warning_type])
                     existing.update(merger.merge_warnings[warning_type])
-                    self.merge_metadata['merge_warnings'][entity_type][warning_type] = sorted(existing)
+                    self.merge_metadata['merge_warnings'][warning_type] = sorted(existing)
 
     def merge_primary_sources(self,
                               graph_sources: list):
@@ -246,10 +245,8 @@ class KGXFileMerger:
         return {'sources': {},
                 'merged_nodes': 0,
                 'merged_edges': 0,
-                'merge_warnings': {'nodes': {'mismatched_properties': [],
-                                             'dropped_properties': []},
-                                   'edges': {'mismatched_properties': [],
-                                             'dropped_properties': []}},
+                'merge_warnings': {'mismatched_properties': [],
+                                   'dropped_properties': []},
                 'final_node_count': 0,
                 'final_edge_count': 0}
 

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -3,7 +3,7 @@ import jsonlines
 import json
 from datetime import datetime
 from itertools import chain
-from orion.utils import quick_jsonl_file_iterator, quick_json_dumps
+from orion.utils import quick_jsonl_file_iterator
 from orion.logging import get_orion_logger
 from orion.kgxmodel import GraphSpec, GraphSource, SubGraphSource
 from orion.biolink_constants import SUBJECT_ID, OBJECT_ID
@@ -183,15 +183,6 @@ class KGXFileMerger:
                 edges_out.write(edge_line)
                 edges_written += 1
 
-        if self.graph_spec.add_edge_id and not self.graph_spec.overwrite_edge_ids:
-            mapping = self.edge_graph_merger.get_pre_merge_edge_id_mapping()
-            mapping_filename = f'pre_merge_edge_id_mapping.jsonl'
-            mapping_file_path = os.path.join(self.output_directory, mapping_filename)
-            logger.info(f'Writing pre-merge edge ID mapping to file...')
-            with open(mapping_file_path, 'w') as mf:
-                for post_merge_id, pre_merge_ids in mapping.items():
-                    mf.write(f'{quick_json_dumps({"post_merge_id": post_merge_id, "pre_merge_ids": pre_merge_ids})}\n')
-
         return nodes_written, edges_written
 
     def __write_unmerged_edges_to_file(self):
@@ -224,6 +215,10 @@ class KGXFileMerger:
                     needs_on_disk_merge = True
                     break
 
+        pre_merge_mapping_file_path = None
+        if self.graph_spec.add_edge_id and not self.graph_spec.overwrite_edge_ids and self.output_directory:
+            pre_merge_mapping_file_path = os.path.join(self.output_directory, 'pre_merge_edge_id_mapping.jsonl')
+
         if needs_on_disk_merge:
             if self.output_directory is None:
                 raise IOError(f'DiskGraphMerger attempted but no output directory was specified.')
@@ -231,12 +226,14 @@ class KGXFileMerger:
                                    edge_merging_attributes=self.graph_spec.edge_merging_attributes,
                                    add_edge_id=self.graph_spec.add_edge_id,
                                    edge_id_type=self.graph_spec.edge_id_type,
-                                   overwrite_edge_ids=self.graph_spec.overwrite_edge_ids)
+                                   overwrite_edge_ids=self.graph_spec.overwrite_edge_ids,
+                                   pre_merge_mapping_file_path=pre_merge_mapping_file_path)
         else:
             return MemoryGraphMerger(edge_merging_attributes=self.graph_spec.edge_merging_attributes,
                                      add_edge_id=self.graph_spec.add_edge_id,
                                      edge_id_type=self.graph_spec.edge_id_type,
-                                     overwrite_edge_ids=self.graph_spec.overwrite_edge_ids)
+                                     overwrite_edge_ids=self.graph_spec.overwrite_edge_ids,
+                                     pre_merge_mapping_file_path=pre_merge_mapping_file_path)
 
     @staticmethod
     def init_merge_metadata():

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -3,7 +3,7 @@ import jsonlines
 import json
 from datetime import datetime
 from itertools import chain
-from orion.utils import quick_jsonl_file_iterator
+from orion.utils import quick_jsonl_file_iterator, quick_json_dumps
 from orion.logging import get_orion_logger
 from orion.kgxmodel import GraphSpec, GraphSource, SubGraphSource
 from orion.biolink_constants import SUBJECT_ID, OBJECT_ID
@@ -183,6 +183,15 @@ class KGXFileMerger:
                 edges_out.write(edge_line)
                 edges_written += 1
 
+        if self.graph_spec.add_edge_id and not self.graph_spec.overwrite_edge_ids:
+            mapping = self.edge_graph_merger.get_pre_merge_edge_id_mapping()
+            mapping_filename = f'pre_merge_edge_id_mapping.jsonl'
+            mapping_file_path = os.path.join(self.output_directory, mapping_filename)
+            logger.info(f'Writing pre-merge edge ID mapping to file...')
+            with open(mapping_file_path, 'w') as mf:
+                for post_merge_id, pre_merge_ids in mapping.items():
+                    mf.write(f'{quick_json_dumps({"post_merge_id": post_merge_id, "pre_merge_ids": pre_merge_ids})}\n')
+
         return nodes_written, edges_written
 
     def __write_unmerged_edges_to_file(self):
@@ -221,11 +230,13 @@ class KGXFileMerger:
             return DiskGraphMerger(temp_directory=self.output_directory,
                                    edge_merging_attributes=self.graph_spec.edge_merging_attributes,
                                    add_edge_id=self.graph_spec.add_edge_id,
-                                   edge_id_type=self.graph_spec.edge_id_type)
+                                   edge_id_type=self.graph_spec.edge_id_type,
+                                   overwrite_edge_ids=self.graph_spec.overwrite_edge_ids)
         else:
             return MemoryGraphMerger(edge_merging_attributes=self.graph_spec.edge_merging_attributes,
                                      add_edge_id=self.graph_spec.add_edge_id,
-                                     edge_id_type=self.graph_spec.edge_id_type)
+                                     edge_id_type=self.graph_spec.edge_id_type,
+                                     overwrite_edge_ids=self.graph_spec.overwrite_edge_ids)
 
     @staticmethod
     def init_merge_metadata():

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -89,6 +89,12 @@ class KGXFileMerger:
             self.merge_metadata['final_edge_count'] += merged_edges_written + unmerged_edges_written
             self.merge_metadata['merged_nodes'] += self.node_graph_merger.merged_node_counter
             self.merge_metadata['merged_edges'] += self.edge_graph_merger.merged_edge_counter
+            for entity_type, merger in (('nodes', self.node_graph_merger),
+                                        ('edges', self.edge_graph_merger)):
+                for warning_type in ('mismatched_properties', 'dropped_properties'):
+                    existing = set(self.merge_metadata['merge_warnings'][entity_type][warning_type])
+                    existing.update(merger.merge_warnings[warning_type])
+                    self.merge_metadata['merge_warnings'][entity_type][warning_type] = sorted(existing)
 
     def merge_primary_sources(self,
                               graph_sources: list):
@@ -240,6 +246,10 @@ class KGXFileMerger:
         return {'sources': {},
                 'merged_nodes': 0,
                 'merged_edges': 0,
+                'merge_warnings': {'nodes': {'mismatched_properties': [],
+                                             'dropped_properties': []},
+                                   'edges': {'mismatched_properties': [],
+                                             'dropped_properties': []}},
                 'final_node_count': 0,
                 'final_edge_count': 0}
 

--- a/orion/kgx_file_normalizer.py
+++ b/orion/kgx_file_normalizer.py
@@ -1,10 +1,10 @@
 import os
 import json
 import jsonlines
-import logging
-from orion.biolink_constants import (SEQUENCE_VARIANT, RETRIEVAL_SOURCES, PRIMARY_KNOWLEDGE_SOURCE,
-                                     AGGREGATOR_KNOWLEDGE_SOURCES, PUBLICATIONS, OBJECT_ID, SUBJECT_ID, PREDICATE,
-                                     SUBCLASS_OF, ORIGINAL_OBJECT, ORIGINAL_SUBJECT)
+from collections import defaultdict
+
+from orion.biolink_constants import (SEQUENCE_VARIANT, RETRIEVAL_SOURCES, PRIMARY_KNOWLEDGE_SOURCE, OBJECT_ID,
+                                     SUBJECT_ID, PREDICATE, SUBCLASS_OF, ORIGINAL_OBJECT, ORIGINAL_SUBJECT)
 from orion.normalization import NormalizationScheme, NodeNormalizer, EdgeNormalizer, EdgeNormalizationResult, \
     NormalizationFailedError
 from orion.utils import chunk_iterator
@@ -12,7 +12,6 @@ from orion.logging import get_orion_logger
 from orion.kgx_file_writer import KGXFileWriter
 
 
-EDGE_PROPERTIES_THAT_SHOULD_BE_SETS = {AGGREGATOR_KNOWLEDGE_SOURCES, PUBLICATIONS}
 NODE_NORMALIZATION_BATCH_SIZE = 1_000_000
 EDGE_NORMALIZATION_BATCH_SIZE = 1_000_000
 
@@ -198,11 +197,19 @@ class KGXFileNormalizer:
                 for failed_node_id, error_message in variant_node_norm_failures.items():
                     failed_norm_file.write(f'{failed_node_id}\t{error_message}\n')
 
+        # compute per-prefix normalization stats
+        prefix_stats = self.compute_by_prefix_stats(
+            node_norm_lookup=self.node_normalizer.node_normalization_lookup,
+            regular_failures=regular_node_norm_failures,
+            variant_failures=set(variant_node_norm_failures.keys())
+        )
+
         # update the metadata
         self.normalization_metadata.update({
             'node_count_pre_normalization': regular_nodes_pre_norm,
             'node_count_post_normalization': regular_nodes_post_norm,
             'node_normalization_failures': len(regular_node_norm_failures),
+            'normalization_by_prefix': prefix_stats,
         })
         if self.has_sequence_variants:
             self.normalization_metadata.update({
@@ -278,6 +285,7 @@ class KGXFileNormalizer:
                             else:
                                 normalized_predicate = edge[PREDICATE]
                                 edge_inverted_by_normalization = False
+                                normalized_edge_properties = None
 
                             # a counter for the number of normalized edges coming from a single source edge
                             # it's only used to determine how many edge splits occurred
@@ -356,6 +364,37 @@ class KGXFileNormalizer:
             'subclass_loops_removed': subclass_loops_removed,
             'final_normalized_edges': normalized_edge_count
         })
+
+    @staticmethod
+    def compute_by_prefix_stats(node_norm_lookup: dict,
+                                regular_failures: set,
+                                variant_failures: set):
+        # count totals per prefix from lookup keys
+        prefix_total = defaultdict(int)
+        for node_id in node_norm_lookup:
+            prefix = node_id.split(':')[0]
+            prefix_total[prefix] += 1
+
+        # count failures per prefix
+        prefix_failed = defaultdict(int)
+        for node_id in regular_failures:
+            prefix_failed[node_id.split(':')[0]] += 1
+        for node_id in variant_failures:
+            prefix_failed[node_id.split(':')[0]] += 1
+
+        prefix_stats = {}
+        for prefix in sorted(prefix_total):
+            failed = prefix_failed.get(prefix, 0)
+            total = prefix_total[prefix]
+            succeeded = total - failed
+            percentage = round(succeeded * 100 / total, 1)
+            prefix_stats[prefix] = {'succeeded': succeeded, 'failed': failed, 'total': total, 'success_rate': percentage}
+            if succeeded == 0:
+                logger.error(f'ATTENTION: Curie prefix "{prefix}" failed normalization for all nodes!!!')
+            elif percentage < 50:
+                logger.warning(f'WARNING: Curie prefix "{prefix}" only normalized {percentage}% of nodes!!!')
+        return prefix_stats
+
 
 def invert_edge(edge):
     inverted_edge = {}

--- a/orion/kgx_file_normalizer.py
+++ b/orion/kgx_file_normalizer.py
@@ -379,20 +379,23 @@ class KGXFileNormalizer:
                 prefix_failed[original_prefix] += 1
 
         prefix_stats = {}
-        for prefix in sorted(prefix_total):
+        # sort the prefixes by their total count, the most common prefix is at the top of the list
+        for prefix in sorted(prefix_total, key=prefix_total.get, reverse=True):
             failed = prefix_failed.get(prefix, 0)
             total = prefix_total[prefix]
             succeeded = total - failed
-            percentage = round(succeeded * 100 / total, 1)
+            percentage = int(succeeded / total * 10000) / 100  # truncate percentage to two decimal places
             prefix_stats[prefix] = {
                 'succeeded': succeeded,
                 'failed': failed,
                 'total': total,
                 'success_rate': percentage,
-                'normalized_to': dict(prefix_normalized_to.get(prefix, {})),
+                # sort normalized_to by curie counts, not alphabetically
+                'normalized_to': dict(sorted(prefix_normalized_to.get(prefix, {}).items(),
+                                             key=lambda x: x[1], reverse=True)),
             }
             if succeeded == 0:
-                logger.error(f'ATTENTION: Curie prefix "{prefix}" failed normalization for all nodes!!!')
+                logger.error(f'!!! --- ATTENTION: Curie prefix "{prefix}" failed normalization for all nodes! --- !!!')
             elif percentage < 50:
                 logger.warning(f'WARNING: Curie prefix "{prefix}" only normalized {percentage}% of nodes!!!')
         return prefix_stats

--- a/orion/kgx_file_normalizer.py
+++ b/orion/kgx_file_normalizer.py
@@ -199,9 +199,7 @@ class KGXFileNormalizer:
 
         # compute per-prefix normalization stats
         prefix_stats = self.compute_by_prefix_stats(
-            node_norm_lookup=self.node_normalizer.node_normalization_lookup,
-            regular_failures=regular_node_norm_failures,
-            variant_failures=set(variant_node_norm_failures.keys())
+            node_norm_lookup=self.node_normalizer.node_normalization_lookup
         )
 
         # update the metadata
@@ -366,21 +364,19 @@ class KGXFileNormalizer:
         })
 
     @staticmethod
-    def compute_by_prefix_stats(node_norm_lookup: dict,
-                                regular_failures: set,
-                                variant_failures: set):
-        # count totals per prefix from lookup keys
+    def compute_by_prefix_stats(node_norm_lookup: dict):
+        # count totals, failures, and post-normalization prefixes per original prefix
         prefix_total = defaultdict(int)
-        for node_id in node_norm_lookup:
-            prefix = node_id.split(':')[0]
-            prefix_total[prefix] += 1
-
-        # count failures per prefix
         prefix_failed = defaultdict(int)
-        for node_id in regular_failures:
-            prefix_failed[node_id.split(':')[0]] += 1
-        for node_id in variant_failures:
-            prefix_failed[node_id.split(':')[0]] += 1
+        prefix_normalized_to = defaultdict(lambda: defaultdict(int))
+        for node_id, normalized_ids in node_norm_lookup.items():
+            original_prefix = node_id.split(':')[0]
+            prefix_total[original_prefix] += 1
+            if normalized_ids:
+                for normalized_id in normalized_ids:
+                    prefix_normalized_to[original_prefix][normalized_id.split(':')[0]] += 1
+            else:
+                prefix_failed[original_prefix] += 1
 
         prefix_stats = {}
         for prefix in sorted(prefix_total):
@@ -388,7 +384,13 @@ class KGXFileNormalizer:
             total = prefix_total[prefix]
             succeeded = total - failed
             percentage = round(succeeded * 100 / total, 1)
-            prefix_stats[prefix] = {'succeeded': succeeded, 'failed': failed, 'total': total, 'success_rate': percentage}
+            prefix_stats[prefix] = {
+                'succeeded': succeeded,
+                'failed': failed,
+                'total': total,
+                'success_rate': percentage,
+                'normalized_to': dict(prefix_normalized_to.get(prefix, {})),
+            }
             if succeeded == 0:
                 logger.error(f'ATTENTION: Curie prefix "{prefix}" failed normalization for all nodes!!!')
             elif percentage < 50:

--- a/orion/kgxmodel.py
+++ b/orion/kgxmodel.py
@@ -44,6 +44,7 @@ class GraphSpec:
     graph_version: str
     graph_output_format: str
     add_edge_id: bool = None
+    overwrite_edge_ids: bool = True
     edge_id_type: str = None
     edge_merging_attributes: list = None
     sources: list = None
@@ -58,6 +59,7 @@ class GraphSpec:
             'graph_version': self.graph_version,
             'edge_merging_attributes': self.edge_merging_attributes,
             'add_edge_id': self.add_edge_id,
+            'overwrite_edge_ids': self.overwrite_edge_ids,
             'edge_id_type': self.edge_id_type,
             'subgraphs': [subgraph.get_metadata_representation() for subgraph in self.subgraphs] if self.subgraphs else [],
             'sources': [source.get_metadata_representation() for source in self.sources] if self.sources else []

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -179,7 +179,7 @@ class DiskGraphMerger(GraphMerger):
 
     def __init__(self, temp_directory: str = None, chunk_size: int = 10_000_000,
                  edge_merging_attributes=None, add_edge_id=False, edge_id_type=None,
-                 overwrite_edge_ids=True):
+                 overwrite_edge_ids=True, pre_merge_mapping_file_path=None):
 
         super().__init__(edge_merging_attributes=edge_merging_attributes,
                          add_edge_id=add_edge_id,
@@ -197,7 +197,11 @@ class DiskGraphMerger(GraphMerger):
             NODE_ENTITY_TYPE: [],
             EDGE_ENTITY_TYPE: []
         }
-        self.pre_merge_edge_id_mapping = {}
+        self.pre_merge_mapping_file_path = pre_merge_mapping_file_path
+        # Transient handle opened by get_merged_edges_jsonl and written to as each merged
+        # key is finalized inside get_merged_entities. Avoids buffering the full mapping
+        # in memory, which would defeat the purpose of DiskGraphMerger.
+        self._pre_merge_mapping_file = None
 
     def merge_node(self, node):
         self.node_ids.add(node['id'])
@@ -271,13 +275,21 @@ class DiskGraphMerger(GraphMerger):
 
     def get_merged_edges_jsonl(self):
         self.flush_edge_buffer()
-        for json_line in self.get_merged_entities(file_paths=self.temp_file_paths[EDGE_ENTITY_TYPE],
-                                                  merge_function=entity_merging_function,
-                                                  entity_type=EDGE_ENTITY_TYPE,
-                                                  track_pre_merge_ids=self.add_edge_id and not self.overwrite_edge_ids):
-            yield json_line
-        for file_path in self.temp_file_paths[EDGE_ENTITY_TYPE]:
-            os.remove(file_path)
+        track_pre_merge_ids = self.add_edge_id and not self.overwrite_edge_ids
+        try:
+            if track_pre_merge_ids and self.pre_merge_mapping_file_path:
+                self._pre_merge_mapping_file = open(self.pre_merge_mapping_file_path, 'w')
+            for json_line in self.get_merged_entities(file_paths=self.temp_file_paths[EDGE_ENTITY_TYPE],
+                                                      merge_function=entity_merging_function,
+                                                      entity_type=EDGE_ENTITY_TYPE,
+                                                      track_pre_merge_ids=track_pre_merge_ids):
+                yield json_line
+            for file_path in self.temp_file_paths[EDGE_ENTITY_TYPE]:
+                os.remove(file_path)
+        finally:
+            if self._pre_merge_mapping_file is not None:
+                self._pre_merge_mapping_file.close()
+                self._pre_merge_mapping_file = None
 
     def flush_edge_buffer(self):
         if not self.entity_buffers[EDGE_ENTITY_TYPE]:
@@ -385,15 +397,25 @@ class DiskGraphMerger(GraphMerger):
                 if track_pre_merge_ids:
                     # It looks like we're overwriting all edge ids, but you don't get here without a merge occurring
                     merged_entity[EDGE_ID] = min_key
-                    if pre_merge_ids:
-                        self.pre_merge_edge_id_mapping[min_key] = pre_merge_ids
+                    if pre_merge_ids and self._pre_merge_mapping_file is not None:
+                        self._pre_merge_mapping_file.write(
+                            f'{quick_json_dumps({"post_merge_id": min_key, "pre_merge_ids": pre_merge_ids})}\n')
                 yield f'{quick_json_dumps(merged_entity)}\n'
             # otherwise we can just write the raw json to file
             else:
                 yield f'{merged_json}\n'
 
     def get_pre_merge_edge_id_mapping(self):
-        return self.pre_merge_edge_id_mapping
+        # Read the mapping back from the streamed file. Primarily for test/debug use;
+        # production flow writes the file directly and does not re-read it.
+        if not self.pre_merge_mapping_file_path or not os.path.exists(self.pre_merge_mapping_file_path):
+            return {}
+        result = {}
+        with open(self.pre_merge_mapping_file_path) as f:
+            for line in f:
+                entry = quick_json_loads(line)
+                result[entry['post_merge_id']] = entry['pre_merge_ids']
+        return result
 
     def flush(self):
         self.flush_node_buffer()
@@ -406,7 +428,8 @@ class MemoryGraphMerger(GraphMerger):
                  edge_merging_attributes=None,
                  add_edge_id=False,
                  edge_id_type=None,
-                 overwrite_edge_ids=True):
+                 overwrite_edge_ids=True,
+                 pre_merge_mapping_file_path=None):
         super().__init__(edge_merging_attributes=edge_merging_attributes,
                          add_edge_id=add_edge_id,
                          edge_id_type=edge_id_type,
@@ -414,6 +437,7 @@ class MemoryGraphMerger(GraphMerger):
         self.nodes = {}
         self.edges = {}
         self.pre_merge_edge_id_mapping = defaultdict(list)
+        self.pre_merge_mapping_file_path = pre_merge_mapping_file_path
 
     # merge a list of nodes (dictionaries not kgxnode objects!) into the existing set
     def merge_nodes(self, nodes):
@@ -478,6 +502,10 @@ class MemoryGraphMerger(GraphMerger):
     def get_merged_edges_jsonl(self):
         for edge in self.edges.values():
             yield f'{edge}\n'
+        if self.pre_merge_mapping_file_path and self.pre_merge_edge_id_mapping:
+            with open(self.pre_merge_mapping_file_path, 'w') as f:
+                for post_merge_id, pre_merge_ids in self.pre_merge_edge_id_mapping.items():
+                    f.write(f'{quick_json_dumps({"post_merge_id": post_merge_id, "pre_merge_ids": pre_merge_ids})}\n')
 
     def get_pre_merge_edge_id_mapping(self):
         return self.pre_merge_edge_id_mapping

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -25,8 +25,7 @@ _mismatched_dict_properties = set()
 # properties where two entities had different values that could not be reconciled.
 _dropped_properties = set()
 
-# use this flush pattern so we can emit warnings after each merge, even if there are many
-# (ie after each set of node/edge files)
+# Emit collected warnings, clear them, and return the collected lists for metadata capture.
 def flush_merge_warnings():
     mismatched = sorted(_mismatched_dict_properties)
     dropped = sorted(_dropped_properties)
@@ -96,19 +95,18 @@ def edge_key_function(edge, custom_key_attributes=None, edge_id_type=None):
 def entity_merging_function(entity_1, entity_2):
     # for every property of entity 2
     for key, entity_2_value in entity_2.items():
-        # if entity 1 also has the property and entity_2_value is not null/empty:
+        # if entity 1 also has the property and entity_2_value is not null:
         if (key in entity_1) and (entity_2_value is not None):
             entity_1_value = entity_1[key]
 
-            # check if one or both of them are lists so we can combine them
+            # classify both values so we can pick the right merge strategy
             entity_1_is_list = isinstance(entity_1_value, list)
             entity_2_is_list = isinstance(entity_2_value, list)
             entity_1_is_dict = isinstance(entity_1_value, dict)
             entity_2_is_dict = isinstance(entity_2_value, dict)
             if entity_1_is_dict and entity_2_is_dict:
-                # Dict-shaped biolink slots are id-keyed by construction, so merging by key is
-                # lossless at the key level. For colliding keys whose values are themselves
-                # schema-shaped dicts, recurse so nested list/dict/scalar slots merge correctly.
+                # merge by key; recursively merging entities in dict values,
+                # truthy-prefer on scalars otherwise keep entity 1's
                 for sub_key, sub_value in entity_2_value.items():
                     if sub_key in entity_1_value:
                         existing_sub_value = entity_1_value[sub_key]
@@ -132,11 +130,10 @@ def entity_merging_function(entity_1, entity_2):
                 # if 1 is a list and 2 isn't, append the value of 2 to the list from 1
                 entity_1_value.append(entity_2_value)
             elif entity_2_is_list:
+                # if 2 is a list and 1 is a non-null scalar, prepend 1 into the list from 2
                 if entity_1_value is not None:
-                    # if 2 is a list and 1 has a value, add the value of 1 to the list from 2
                     entity_1[key] = [entity_1_value] + entity_2_value
                 else:
-                    # if 2 is a list and 1 doesn't have a value, just use the list from 2
                     entity_1[key] = entity_2_value
             else:
                 # scalar/scalar: prefer the truthy value. Falsy values (None, 0, "", False)
@@ -170,8 +167,8 @@ def entity_merging_function(entity_1, entity_2):
                     entity_1[key] = list(grouped.values())
                 else:
                     entity_1[key] = sorted(set(entity_1[key]))
-        else:
-            # if entity 1 doesn't have the property, add the property from entity 2
+        elif key not in entity_1:
+            # entity 1 doesn't have the property, copy it from entity 2
             entity_1[key] = entity_2_value
     return entity_1
 

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -1,6 +1,7 @@
 import heapq
 import os
 import secrets
+from collections import defaultdict
 import uuid_utils as uuid
 from xxhash import xxh64_hexdigest
 from orion.biolink_utils import BiolinkUtils
@@ -129,12 +130,22 @@ def entity_merging_function(entity_1, entity_2):
 
 class GraphMerger:
 
-    def __init__(self, edge_merging_attributes=None, add_edge_id=False, edge_id_type=None):
+    def __init__(self,
+                 edge_merging_attributes=None,
+                 add_edge_id=False,
+                 edge_id_type=None,
+                 overwrite_edge_ids=True):
         self.merged_node_counter = 0
         self.merged_edge_counter = 0
         self.edge_merging_attributes = edge_merging_attributes
         self.add_edge_id = add_edge_id
         self.edge_id_type = edge_id_type
+        # overwrite_edge_ids only has effect when add_edge_id is true.
+        # When add_edge_id is true and overwrite_edge_ids is false: existing edge ids are preserved
+        # for edges not involved in a merge; a generated id is assigned only when missing or when
+        # a merge actually occurs. For merged edges, a mapping from the new id to the original
+        # pre-merge ids is recorded in pre_merge_edge_id_mapping.
+        self.overwrite_edge_ids = overwrite_edge_ids
 
     def merge_nodes(self, nodes_iterable):
         raise NotImplementedError
@@ -160,15 +171,20 @@ class GraphMerger:
     def get_merged_edges_jsonl(self):
         raise NotImplementedError
 
+    def get_pre_merge_edge_id_mapping(self):
+        raise NotImplementedError
+
 
 class DiskGraphMerger(GraphMerger):
 
     def __init__(self, temp_directory: str = None, chunk_size: int = 10_000_000,
-                 edge_merging_attributes=None, add_edge_id=False, edge_id_type=None):
+                 edge_merging_attributes=None, add_edge_id=False, edge_id_type=None,
+                 overwrite_edge_ids=True):
 
         super().__init__(edge_merging_attributes=edge_merging_attributes,
                          add_edge_id=add_edge_id,
-                         edge_id_type=edge_id_type)
+                         edge_id_type=edge_id_type,
+                         overwrite_edge_ids=overwrite_edge_ids)
 
         self.chunk_size = chunk_size
         self.temp_directory = temp_directory
@@ -181,6 +197,7 @@ class DiskGraphMerger(GraphMerger):
             NODE_ENTITY_TYPE: [],
             EDGE_ENTITY_TYPE: []
         }
+        self.pre_merge_edge_id_mapping = {}
 
     def merge_node(self, node):
         self.node_ids.add(node['id'])
@@ -199,9 +216,17 @@ class DiskGraphMerger(GraphMerger):
     def merge_edge(self, edge):
         key = edge_key_function(edge, custom_key_attributes=self.edge_merging_attributes,
                                 edge_id_type=self.edge_id_type)
-        if self.add_edge_id:
-            edge[EDGE_ID] = key
-        self.entity_buffers[EDGE_ENTITY_TYPE].append((key, quick_json_dumps(edge)))
+        if self.add_edge_id and not self.overwrite_edge_ids:
+            # pre_merge_id must be captured before adding a new id,
+            # so that if they don't exist they aren't recorded in the merge mapping.
+            pre_merge_id = edge.get(EDGE_ID)
+            if pre_merge_id is None:
+                edge[EDGE_ID] = key
+            self.entity_buffers[EDGE_ENTITY_TYPE].append((key, quick_json_dumps(edge), pre_merge_id))
+        else:
+            if self.add_edge_id:
+                edge[EDGE_ID] = key
+            self.entity_buffers[EDGE_ENTITY_TYPE].append((key, quick_json_dumps(edge)))
         if len(self.entity_buffers[EDGE_ENTITY_TYPE]) >= self.chunk_size:
             self.flush_edge_buffer()
 
@@ -217,8 +242,12 @@ class DiskGraphMerger(GraphMerger):
         temp_file_name = f'{entity_type}_{secrets.token_hex(6)}.temp'
         temp_file_path = os.path.join(self.temp_directory, temp_file_name)
         with open(temp_file_path, 'w') as temp_file:
-            for key, entity_json in keyed_entities:
-                temp_file.write(f'{key}{entity_json}\n')
+            if self.add_edge_id and not self.overwrite_edge_ids and entity_type == EDGE_ENTITY_TYPE:
+                for key, entity_json, pre_merge_id in keyed_entities:
+                    temp_file.write(f'{pre_merge_id or ""}\t{key}{entity_json}\n')
+            else:
+                for key, entity_json in keyed_entities:
+                    temp_file.write(f'{key}{entity_json}\n')
         self.temp_file_paths[entity_type].append(temp_file_path)
 
     def get_node_ids(self):
@@ -244,7 +273,8 @@ class DiskGraphMerger(GraphMerger):
         self.flush_edge_buffer()
         for json_line in self.get_merged_entities(file_paths=self.temp_file_paths[EDGE_ENTITY_TYPE],
                                                   merge_function=entity_merging_function,
-                                                  entity_type=EDGE_ENTITY_TYPE):
+                                                  entity_type=EDGE_ENTITY_TYPE,
+                                                  track_pre_merge_ids=self.add_edge_id and not self.overwrite_edge_ids):
             yield json_line
         for file_path in self.temp_file_paths[EDGE_ENTITY_TYPE]:
             os.remove(file_path)
@@ -262,10 +292,20 @@ class DiskGraphMerger(GraphMerger):
         json_start = line.index('{')
         return line[:json_start], line[json_start:].rstrip('\n')
 
+    @staticmethod
+    def parse_keyed_line_with_pre_merge_id(line):
+        # Split a line with format: {pre_merge_id}\t{key}{json}\n
+        tab_pos = line.index('\t')
+        pre_merge_id = line[:tab_pos] or None
+        rest = line[tab_pos + 1:]
+        json_start = rest.index('{')
+        return pre_merge_id, rest[:json_start], rest[json_start:].rstrip('\n')
+
     def get_merged_entities(self,
                             file_paths,
                             merge_function,
-                            entity_type):
+                            entity_type,
+                            track_pre_merge_ids=False):
 
         # open all the files, which are chunk_size sized files of sorted and keyed entities
         if not file_paths:
@@ -278,16 +318,22 @@ class DiskGraphMerger(GraphMerger):
 
         # Here we use a min-heap to organize iterating through the entity files to compare their keys and merge entities
         # with matching keys. Members of the heap are tuples representing each line from a file:
-        # (key, file_index, raw_json) where key is the previously calculated merging key for an entity, and raw_json
-        # is the raw json string for an entity.
+        # (key, file_index, raw_json) or (key, file_index, pre_merge_id, raw_json) when tracking pre-merge IDs.
+        # key is the previously calculated merging key for an entity, and raw_json is the raw json string for an entity.
+
+        parse_line = self.parse_keyed_line_with_pre_merge_id if track_pre_merge_ids else self.parse_keyed_line
 
         # First start the heap with the first line from each file.
         heap = []
         for i, fh in enumerate(file_handlers):
             line = fh.readline()
             if line:
-                key, raw_json = self.parse_keyed_line(line)
-                heap.append((key, i, raw_json))
+                if track_pre_merge_ids:
+                    pre_merge_id, key, raw_json = parse_line(line)
+                    heap.append((key, i, pre_merge_id, raw_json))
+                else:
+                    key, raw_json = parse_line(line)
+                    heap.append((key, i, raw_json))
             else:
                 fh.close()
         heapq.heapify(heap)
@@ -298,9 +344,17 @@ class DiskGraphMerger(GraphMerger):
             min_key = heap[0][0]
             merged_entity = None
             merged_json = None
+            pre_merge_ids = [] if track_pre_merge_ids else None
+
             # Pop all entries with the current minimum key and merge them together
             while heap and heap[0][0] == min_key:
-                key, i, raw_json = heapq.heappop(heap)
+                if track_pre_merge_ids:
+                    key, i, pre_merge_id, raw_json = heapq.heappop(heap)
+                    if pre_merge_id is not None:
+                        pre_merge_ids.append(pre_merge_id)
+                else:
+                    key, i, raw_json = heapq.heappop(heap)
+
                 # If there's a merged entity it means we already merged entities with this key, use the same object
                 if merged_entity is not None:
                     merged_entity = merge_function(merged_entity, quick_json_loads(raw_json))
@@ -317,17 +371,29 @@ class DiskGraphMerger(GraphMerger):
                 # read the next line from this file
                 line = file_handlers[i].readline()
                 if line:
-                    next_key, next_raw_json = self.parse_keyed_line(line)
-                    heapq.heappush(heap, (next_key, i, next_raw_json))
+                    if track_pre_merge_ids:
+                        next_pre_merge_id, next_key, next_raw_json = parse_line(line)
+                        heapq.heappush(heap, (next_key, i, next_pre_merge_id, next_raw_json))
+                    else:
+                        next_key, next_raw_json = parse_line(line)
+                        heapq.heappush(heap, (next_key, i, next_raw_json))
                 else:
                     file_handlers[i].close()
 
-            # if we did a merge we need to convert back to a json string for writing
+            # If we did a merge we need to convert back to a json string for writing, and apply a new id if desired
             if merged_entity is not None:
+                if track_pre_merge_ids:
+                    # It looks like we're overwriting all edge ids, but you don't get here without a merge occurring
+                    merged_entity[EDGE_ID] = min_key
+                    if pre_merge_ids:
+                        self.pre_merge_edge_id_mapping[min_key] = pre_merge_ids
                 yield f'{quick_json_dumps(merged_entity)}\n'
             # otherwise we can just write the raw json to file
             else:
                 yield f'{merged_json}\n'
+
+    def get_pre_merge_edge_id_mapping(self):
+        return self.pre_merge_edge_id_mapping
 
     def flush(self):
         self.flush_node_buffer()
@@ -336,12 +402,18 @@ class DiskGraphMerger(GraphMerger):
 
 class MemoryGraphMerger(GraphMerger):
 
-    def __init__(self, edge_merging_attributes=None, add_edge_id=False, edge_id_type=None):
+    def __init__(self,
+                 edge_merging_attributes=None,
+                 add_edge_id=False,
+                 edge_id_type=None,
+                 overwrite_edge_ids=True):
         super().__init__(edge_merging_attributes=edge_merging_attributes,
                          add_edge_id=add_edge_id,
-                         edge_id_type=edge_id_type)
+                         edge_id_type=edge_id_type,
+                         overwrite_edge_ids=overwrite_edge_ids)
         self.nodes = {}
         self.edges = {}
+        self.pre_merge_edge_id_mapping = defaultdict(list)
 
     # merge a list of nodes (dictionaries not kgxnode objects!) into the existing set
     def merge_nodes(self, nodes):
@@ -375,13 +447,24 @@ class MemoryGraphMerger(GraphMerger):
                                      edge_id_type=self.edge_id_type)
         if edge_key in self.edges:
             self.merged_edge_counter += 1
-            merged_edge = entity_merging_function(quick_json_loads(self.edges[edge_key]),
-                                                  edge)
+            existing_edge = quick_json_loads(self.edges[edge_key])
+            if self.add_edge_id and not self.overwrite_edge_ids:
+                mapping = self.pre_merge_edge_id_mapping
+                if edge_key not in mapping:
+                    # Capture the stored edge's original id. Skip if it equals edge_key,
+                    # that means the id was generated during merging or wasn't changed and doesn't need mapping.
+                    existing_id = existing_edge.get(EDGE_ID)
+                    if existing_id is not None and existing_id != edge_key:
+                        mapping[edge_key].append(existing_id)
+                new_id = edge.get(EDGE_ID)
+                if new_id is not None:
+                    mapping[edge_key].append(new_id)
+            merged_edge = entity_merging_function(existing_edge, edge)
             if self.add_edge_id:
                 merged_edge[EDGE_ID] = edge_key
             self.edges[edge_key] = quick_json_dumps(merged_edge)
         else:
-            if self.add_edge_id:
+            if self.add_edge_id and (self.overwrite_edge_ids or EDGE_ID not in edge):
                 edge[EDGE_ID] = edge_key
             self.edges[edge_key] = quick_json_dumps(edge)
 
@@ -395,3 +478,6 @@ class MemoryGraphMerger(GraphMerger):
     def get_merged_edges_jsonl(self):
         for edge in self.edges.values():
             yield f'{edge}\n'
+
+    def get_pre_merge_edge_id_mapping(self):
+        return self.pre_merge_edge_id_mapping

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -6,6 +6,7 @@ import uuid_utils as uuid
 from xxhash import xxh64_hexdigest
 from orion.biolink_utils import BiolinkUtils
 from orion.biolink_constants import *
+import orjson
 from orion.utils import quick_json_loads, quick_json_dumps
 from orion.logging import get_orion_logger
 
@@ -42,9 +43,10 @@ def flush_merge_warnings():
 # Key functions for identifying duplicates during entity merging.
 # Add entries to CUSTOM_KEY_FUNCTIONS to define custom matching logic for specific properties.
 
-# Default key function: dictionaries are duplicates if they have identical JSON representation
+# Default key function: dictionaries are duplicates if they have identical JSON representation.
+# Sort keys so two logically-equal dicts with different insertion order produce the same key.
 def default_dict_merge_key(entity):
-    return quick_json_dumps(entity)
+    return orjson.dumps(entity, option=orjson.OPT_SORT_KEYS)
 
 # Retrieval sources are duplicates if they have the same resource id and resource role
 def retrieval_sources_key(retrieval_source):

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -314,9 +314,10 @@ class DiskGraphMerger(GraphMerger):
                                                       merge_function=entity_merging_function,
                                                       entity_type=NODE_ENTITY_TYPE):
                 yield json_line
-            for file_path in self.temp_file_paths[NODE_ENTITY_TYPE]:
-                os.remove(file_path)
         finally:
+            for file_path in self.temp_file_paths[NODE_ENTITY_TYPE]:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
             self._record_merge_warnings(flush_merge_warnings())
 
     def flush_node_buffer(self):
@@ -337,9 +338,10 @@ class DiskGraphMerger(GraphMerger):
                                                       entity_type=EDGE_ENTITY_TYPE,
                                                       track_pre_merge_ids=track_pre_merge_ids):
                 yield json_line
-            for file_path in self.temp_file_paths[EDGE_ENTITY_TYPE]:
-                os.remove(file_path)
         finally:
+            for file_path in self.temp_file_paths[EDGE_ENTITY_TYPE]:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
             if self._pre_merge_mapping_file is not None:
                 self._pre_merge_mapping_file.close()
                 self._pre_merge_mapping_file = None

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -19,6 +19,26 @@ bmt = BiolinkUtils()
 
 logger = get_orion_logger("orion.merging")
 
+# mismatches where one entity has a dict for a property and another has another type.
+_mismatched_dict_properties = set()
+# properties where two entities had different values that could not be reconciled.
+_dropped_properties = set()
+
+# use this flush pattern so we can emit warnings after each merge, even if there are many
+# (ie after each set of node/edge files)
+def flush_merge_warnings():
+    mismatched = sorted(_mismatched_dict_properties)
+    dropped = sorted(_dropped_properties)
+    if mismatched:
+        logger.warning(f'Mismatched types encountered while merging properties: '
+                       f'{mismatched}. entity_1 values were kept.')
+    if dropped:
+        logger.warning(f'Property value collisions encountered while merging properties: '
+                       f'{dropped}. entity_1 values were kept, entity_2 values were dropped.')
+    _mismatched_dict_properties.clear()
+    _dropped_properties.clear()
+    return {'mismatched_properties': mismatched, 'dropped_properties': dropped}
+
 # Key functions for identifying duplicates during entity merging.
 # Add entries to CUSTOM_KEY_FUNCTIONS to define custom matching logic for specific properties.
 
@@ -81,7 +101,27 @@ def entity_merging_function(entity_1, entity_2):
             # check if one or both of them are lists so we can combine them
             entity_1_is_list = isinstance(entity_1_value, list)
             entity_2_is_list = isinstance(entity_2_value, list)
-            if entity_1_is_list and entity_2_is_list:
+            entity_1_is_dict = isinstance(entity_1_value, dict)
+            entity_2_is_dict = isinstance(entity_2_value, dict)
+            if entity_1_is_dict and entity_2_is_dict:
+                # Dict-shaped biolink slots are id-keyed by construction, so merging by key is
+                # lossless at the key level. For colliding keys whose values are themselves
+                # schema-shaped dicts, recurse so nested list/dict/scalar slots merge correctly.
+                for sub_key, sub_value in entity_2_value.items():
+                    if sub_key in entity_1_value:
+                        existing_sub_value = entity_1_value[sub_key]
+                        if isinstance(existing_sub_value, dict) and isinstance(sub_value, dict):
+                            entity_1_value[sub_key] = entity_merging_function(existing_sub_value, sub_value)
+                        elif existing_sub_value is None:
+                            entity_1_value[sub_key] = sub_value
+                        elif existing_sub_value != sub_value:
+                            # keep entity_1's value, matching the scalar policy below
+                            _dropped_properties.add(key)
+                    else:
+                        entity_1_value[sub_key] = sub_value
+            elif entity_1_is_dict or entity_2_is_dict:
+                _mismatched_dict_properties.add(key)
+            elif entity_1_is_list and entity_2_is_list:
                 # if they're both lists just concat them
                 entity_1_value.extend(entity_2_value)
             elif entity_1_is_list:
@@ -99,7 +139,9 @@ def entity_merging_function(entity_1, entity_2):
                 if entity_1_value is None:
                     # if entity_1's value is None, use entity_2's value
                     entity_1[key] = entity_2_value
-                # else: keep the value from entity_1
+                elif entity_1_value != entity_2_value:
+                    # keep the value from entity_1, entity_2's differing value is dropped
+                    _dropped_properties.add(key)
 
             # if either was a list remove duplicate values
             if entity_1_is_list or entity_2_is_list:
@@ -137,6 +179,7 @@ class GraphMerger:
                  overwrite_edge_ids=True):
         self.merged_node_counter = 0
         self.merged_edge_counter = 0
+        self.merge_warnings = {'mismatched_properties': set(), 'dropped_properties': set()}
         self.edge_merging_attributes = edge_merging_attributes
         self.add_edge_id = add_edge_id
         self.edge_id_type = edge_id_type
@@ -173,6 +216,10 @@ class GraphMerger:
 
     def get_pre_merge_edge_id_mapping(self):
         raise NotImplementedError
+
+    def _record_merge_warnings(self, warnings):
+        self.merge_warnings['mismatched_properties'].update(warnings['mismatched_properties'])
+        self.merge_warnings['dropped_properties'].update(warnings['dropped_properties'])
 
 
 class DiskGraphMerger(GraphMerger):
@@ -259,12 +306,15 @@ class DiskGraphMerger(GraphMerger):
 
     def get_merged_nodes_jsonl(self):
         self.flush_node_buffer()
-        for json_line in self.get_merged_entities(file_paths=self.temp_file_paths[NODE_ENTITY_TYPE],
-                                                  merge_function=entity_merging_function,
-                                                  entity_type=NODE_ENTITY_TYPE):
-            yield json_line
-        for file_path in self.temp_file_paths[NODE_ENTITY_TYPE]:
-            os.remove(file_path)
+        try:
+            for json_line in self.get_merged_entities(file_paths=self.temp_file_paths[NODE_ENTITY_TYPE],
+                                                      merge_function=entity_merging_function,
+                                                      entity_type=NODE_ENTITY_TYPE):
+                yield json_line
+            for file_path in self.temp_file_paths[NODE_ENTITY_TYPE]:
+                os.remove(file_path)
+        finally:
+            self._record_merge_warnings(flush_merge_warnings())
 
     def flush_node_buffer(self):
         if not self.entity_buffers[NODE_ENTITY_TYPE]:
@@ -290,6 +340,7 @@ class DiskGraphMerger(GraphMerger):
             if self._pre_merge_mapping_file is not None:
                 self._pre_merge_mapping_file.close()
                 self._pre_merge_mapping_file = None
+            self._record_merge_warnings(flush_merge_warnings())
 
     def flush_edge_buffer(self):
         if not self.entity_buffers[EDGE_ENTITY_TYPE]:
@@ -498,6 +549,7 @@ class MemoryGraphMerger(GraphMerger):
     def get_merged_nodes_jsonl(self):
         for node in self.nodes.values():
             yield f'{quick_json_dumps(node)}\n'
+        self._record_merge_warnings(flush_merge_warnings())
 
     def get_merged_edges_jsonl(self):
         for edge in self.edges.values():
@@ -506,6 +558,7 @@ class MemoryGraphMerger(GraphMerger):
             with open(self.pre_merge_mapping_file_path, 'w') as f:
                 for post_merge_id, pre_merge_ids in self.pre_merge_edge_id_mapping.items():
                     f.write(f'{quick_json_dumps({"post_merge_id": post_merge_id, "pre_merge_ids": pre_merge_ids})}\n')
+        self._record_merge_warnings(flush_merge_warnings())
 
     def get_pre_merge_edge_id_mapping(self):
         return self.pre_merge_edge_id_mapping

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -114,10 +114,12 @@ def entity_merging_function(entity_1, entity_2):
                         existing_sub_value = entity_1_value[sub_key]
                         if isinstance(existing_sub_value, dict) and isinstance(sub_value, dict):
                             entity_1_value[sub_key] = entity_merging_function(existing_sub_value, sub_value)
-                        elif existing_sub_value is None:
+                        elif not existing_sub_value:
                             entity_1_value[sub_key] = sub_value
+                        elif not sub_value:
+                            pass  # keep entity_1; sub_value is falsy
                         elif existing_sub_value != sub_value:
-                            # keep entity_1's value, matching the scalar policy below
+                            # both truthy and differ; keep entity_1 and record the drop
                             _dropped_properties.add(key)
                     else:
                         entity_1_value[sub_key] = sub_value
@@ -137,12 +139,14 @@ def entity_merging_function(entity_1, entity_2):
                     # if 2 is a list and 1 doesn't have a value, just use the list from 2
                     entity_1[key] = entity_2_value
             else:
-                # if neither is a list
-                if entity_1_value is None:
-                    # if entity_1's value is None, use entity_2's value
+                # scalar/scalar: prefer the truthy value. Falsy values (None, 0, "", False)
+                # lose to any truthy value from the other entity.
+                if not entity_1_value:
                     entity_1[key] = entity_2_value
+                elif not entity_2_value:
+                    pass  # keep entity_1; entity_2 is falsy, nothing meaningful to drop
                 elif entity_1_value != entity_2_value:
-                    # keep the value from entity_1, entity_2's differing value is dropped
+                    # both truthy and differ; keep entity_1 and record that entity_2 was dropped
                     _dropped_properties.add(key)
 
             # if either was a list remove duplicate values

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -493,3 +493,165 @@ def test_uuid_edge_id_deterministic_in_memory():
 def test_uuid_edge_id_deterministic_on_disk(tmp_path):
     uuid_edge_id_deterministic_test(lambda: DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=8,
                                                              add_edge_id=True, edge_id_type='uuid'))
+
+
+def overwrite_edge_ids_replaces_existing_test(graph_merger: GraphMerger):
+    # default: add_edge_id=True, overwrite_edge_ids=True — existing ids are always replaced
+    test_edges = [make_edge(1, 2, **{EDGE_ID: 'original_edge_id', 'prop': [i]})
+                  for i in range(1, 4)]
+    graph_merger.merge_edges(test_edges)
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 1
+    assert merged_edges[0][EDGE_ID] != 'original_edge_id'
+    assert graph_merger.get_pre_merge_edge_id_mapping() == {}
+
+
+def test_overwrite_edge_ids_replaces_existing_in_memory():
+    overwrite_edge_ids_replaces_existing_test(MemoryGraphMerger(add_edge_id=True))
+
+
+def test_overwrite_edge_ids_replaces_existing_on_disk(tmp_path):
+    overwrite_edge_ids_replaces_existing_test(DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
+                                                              add_edge_id=True))
+
+
+def preserve_singleton_with_existing_id_test(graph_merger: GraphMerger):
+    # add_edge_id=True, overwrite_edge_ids=False — a singleton edge with an id keeps its id
+    graph_merger.merge_edges([make_edge(1, 2, **{EDGE_ID: 'original_edge_id'})])
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 1
+    assert merged_edges[0][EDGE_ID] == 'original_edge_id'
+    assert graph_merger.get_pre_merge_edge_id_mapping() == {}
+
+
+def test_preserve_singleton_with_existing_id_in_memory():
+    preserve_singleton_with_existing_id_test(
+        MemoryGraphMerger(add_edge_id=True, overwrite_edge_ids=False))
+
+
+def test_preserve_singleton_with_existing_id_on_disk(tmp_path):
+    preserve_singleton_with_existing_id_test(
+        DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
+                        add_edge_id=True, overwrite_edge_ids=False))
+
+
+def preserve_singleton_without_id_gets_generated_test(graph_merger: GraphMerger):
+    # add_edge_id=True, overwrite_edge_ids=False — a singleton edge with no id gets a new one;
+    # it is NOT recorded in the mapping (no original to map from)
+    graph_merger.merge_edges([make_edge(1, 2)])
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 1
+    assert merged_edges[0].get(EDGE_ID) is not None
+    assert graph_merger.get_pre_merge_edge_id_mapping() == {}
+
+
+def test_preserve_singleton_without_id_in_memory():
+    preserve_singleton_without_id_gets_generated_test(
+        MemoryGraphMerger(add_edge_id=True, overwrite_edge_ids=False))
+
+
+def test_preserve_singleton_without_id_on_disk(tmp_path):
+    preserve_singleton_without_id_gets_generated_test(
+        DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
+                        add_edge_id=True, overwrite_edge_ids=False))
+
+
+def preserve_merge_records_original_ids_test(graph_merger: GraphMerger):
+    # add_edge_id=True, overwrite_edge_ids=False — merged edges get a new id (the merge key),
+    # and the mapping records each original pre-merge id
+    test_edges = [make_edge(1, 2, **{EDGE_ID: f'orig_{i}', 'prop': [i]})
+                  for i in range(1, 4)]
+    graph_merger.merge_edges(test_edges)
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 1
+    new_id = merged_edges[0][EDGE_ID]
+    assert new_id not in {'orig_1', 'orig_2', 'orig_3'}
+    mapping = graph_merger.get_pre_merge_edge_id_mapping()
+    assert set(mapping.keys()) == {new_id}
+    assert sorted(mapping[new_id]) == ['orig_1', 'orig_2', 'orig_3']
+
+
+def test_preserve_merge_records_original_ids_in_memory():
+    preserve_merge_records_original_ids_test(
+        MemoryGraphMerger(add_edge_id=True, overwrite_edge_ids=False))
+
+
+def test_preserve_merge_records_original_ids_on_disk(tmp_path):
+    preserve_merge_records_original_ids_test(
+        DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
+                        add_edge_id=True, overwrite_edge_ids=False))
+
+
+def preserve_merge_partial_ids_test(graph_merger: GraphMerger):
+    # add_edge_id=True, overwrite_edge_ids=False — when only some merged edges had ids,
+    # the mapping records only those
+    test_edges = [
+        make_edge(1, 2, **{EDGE_ID: 'orig_A', 'prop': [1]}),
+        make_edge(1, 2, **{'prop': [2]}),
+        make_edge(1, 2, **{EDGE_ID: 'orig_C', 'prop': [3]}),
+    ]
+    graph_merger.merge_edges(test_edges)
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 1
+    new_id = merged_edges[0][EDGE_ID]
+    mapping = graph_merger.get_pre_merge_edge_id_mapping()
+    assert sorted(mapping[new_id]) == ['orig_A', 'orig_C']
+
+
+def test_preserve_merge_partial_ids_in_memory():
+    preserve_merge_partial_ids_test(
+        MemoryGraphMerger(add_edge_id=True, overwrite_edge_ids=False))
+
+
+def test_preserve_merge_partial_ids_on_disk(tmp_path):
+    preserve_merge_partial_ids_test(
+        DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
+                        add_edge_id=True, overwrite_edge_ids=False))
+
+
+def preserve_merge_no_original_ids_test(graph_merger: GraphMerger):
+    # add_edge_id=True, overwrite_edge_ids=False — a merge where no edges had ids
+    # still assigns the generated key to the result but leaves the mapping empty
+    test_edges = [make_edge(1, 2, **{'prop': [i]}) for i in range(1, 4)]
+    graph_merger.merge_edges(test_edges)
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 1
+    assert merged_edges[0].get(EDGE_ID) is not None
+    assert graph_merger.get_pre_merge_edge_id_mapping() == {}
+
+
+def test_preserve_merge_no_original_ids_in_memory():
+    preserve_merge_no_original_ids_test(
+        MemoryGraphMerger(add_edge_id=True, overwrite_edge_ids=False))
+
+
+def test_preserve_merge_no_original_ids_on_disk(tmp_path):
+    preserve_merge_no_original_ids_test(
+        DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
+                        add_edge_id=True, overwrite_edge_ids=False))
+
+
+def preserve_flag_ignored_without_add_edge_id_test(graph_merger: GraphMerger):
+    # add_edge_id=False with overwrite_edge_ids=False — flag has no effect;
+    # no ids are added, existing ones are untouched, mapping is empty
+    test_edges = [
+        make_edge(1, 2, **{EDGE_ID: 'orig_A', 'prop': [1]}),
+        make_edge(1, 2, **{'prop': [2]}),
+    ]
+    graph_merger.merge_edges(test_edges)
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    assert len(merged_edges) == 1
+    # the stored edge is whichever was seen first; its id (if any) is whatever the merge function kept
+    # but no NEW id should have been assigned by the merger itself
+    assert graph_merger.get_pre_merge_edge_id_mapping() == {}
+
+
+def test_preserve_flag_ignored_without_add_edge_id_in_memory():
+    preserve_flag_ignored_without_add_edge_id_test(
+        MemoryGraphMerger(add_edge_id=False, overwrite_edge_ids=False))
+
+
+def test_preserve_flag_ignored_without_add_edge_id_on_disk(tmp_path):
+    preserve_flag_ignored_without_add_edge_id_test(
+        DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
+                        add_edge_id=False, overwrite_edge_ids=False))

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -660,3 +660,58 @@ def test_preserve_flag_ignored_without_add_edge_id_on_disk(tmp_path):
     preserve_flag_ignored_without_add_edge_id_test(
         DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
                         add_edge_id=False, overwrite_edge_ids=False))
+
+
+def truthy_scalar_collision_test(graph_merger: GraphMerger):
+    # scalar/scalar merges: the truthy value always wins regardless of which entity has it.
+    # falsy values (None, 0, "", False) lose to any truthy value from the other entity,
+    # and when both are truthy-but-different the first one wins and the second is recorded as dropped.
+    test_edges = [
+        # falsy on left, truthy on right -> right wins, no drop recorded
+        make_edge(1, 2, zero_then_int=0,     empty_then_str="",    none_then_str=None),
+        make_edge(1, 2, zero_then_int=5,     empty_then_str="foo", none_then_str="bar"),
+        # truthy on left, falsy on right -> left wins, no drop recorded
+        make_edge(3, 4, int_then_zero=5,     str_then_empty="foo", str_then_none="bar"),
+        make_edge(3, 4, int_then_zero=0,     str_then_empty="",    str_then_none=None),
+        # both truthy but differ -> first wins, second dropped
+        make_edge(5, 6, conflicting="first"),
+        make_edge(5, 6, conflicting="second"),
+        # both truthy and equal -> no drop recorded
+        make_edge(7, 8, agreeing="same"),
+        make_edge(7, 8, agreeing="same"),
+    ]
+    graph_merger.merge_edges(test_edges)
+    merged_edges = [json.loads(e) for e in graph_merger.get_merged_edges_jsonl()]
+    edges_by_subject = {e[SUBJECT_ID]: e for e in merged_edges}
+
+    falsy_left = edges_by_subject['NODE:1']
+    assert falsy_left['zero_then_int'] == 5
+    assert falsy_left['empty_then_str'] == "foo"
+    assert falsy_left['none_then_str'] == "bar"
+
+    truthy_left = edges_by_subject['NODE:3']
+    assert truthy_left['int_then_zero'] == 5
+    assert truthy_left['str_then_empty'] == "foo"
+    assert truthy_left['str_then_none'] == "bar"
+
+    conflict = edges_by_subject['NODE:5']
+    assert conflict['conflicting'] == "first"
+
+    agreeing = edges_by_subject['NODE:7']
+    assert agreeing['agreeing'] == "same"
+
+    # only the genuine truthy/truthy collision should be recorded as dropped;
+    # falsy-vs-truthy and equal-value merges must not show up here
+    dropped = graph_merger.merge_warnings['dropped_properties']
+    assert 'conflicting' in dropped
+    for name in ('zero_then_int', 'empty_then_str', 'none_then_str',
+                 'int_then_zero', 'str_then_empty', 'str_then_none', 'agreeing'):
+        assert name not in dropped
+
+
+def test_truthy_scalar_collision_in_memory():
+    truthy_scalar_collision_test(MemoryGraphMerger())
+
+
+def test_truthy_scalar_collision_on_disk(tmp_path):
+    truthy_scalar_collision_test(DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4))

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -532,7 +532,8 @@ def test_preserve_singleton_with_existing_id_in_memory():
 def test_preserve_singleton_with_existing_id_on_disk(tmp_path):
     preserve_singleton_with_existing_id_test(
         DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
-                        add_edge_id=True, overwrite_edge_ids=False))
+                        add_edge_id=True, overwrite_edge_ids=False,
+                        pre_merge_mapping_file_path=str(tmp_path / 'mapping.jsonl')))
 
 
 def preserve_singleton_without_id_gets_generated_test(graph_merger: GraphMerger):
@@ -553,7 +554,8 @@ def test_preserve_singleton_without_id_in_memory():
 def test_preserve_singleton_without_id_on_disk(tmp_path):
     preserve_singleton_without_id_gets_generated_test(
         DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
-                        add_edge_id=True, overwrite_edge_ids=False))
+                        add_edge_id=True, overwrite_edge_ids=False,
+                        pre_merge_mapping_file_path=str(tmp_path / 'mapping.jsonl')))
 
 
 def preserve_merge_records_original_ids_test(graph_merger: GraphMerger):
@@ -579,7 +581,8 @@ def test_preserve_merge_records_original_ids_in_memory():
 def test_preserve_merge_records_original_ids_on_disk(tmp_path):
     preserve_merge_records_original_ids_test(
         DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
-                        add_edge_id=True, overwrite_edge_ids=False))
+                        add_edge_id=True, overwrite_edge_ids=False,
+                        pre_merge_mapping_file_path=str(tmp_path / 'mapping.jsonl')))
 
 
 def preserve_merge_partial_ids_test(graph_merger: GraphMerger):
@@ -606,7 +609,8 @@ def test_preserve_merge_partial_ids_in_memory():
 def test_preserve_merge_partial_ids_on_disk(tmp_path):
     preserve_merge_partial_ids_test(
         DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
-                        add_edge_id=True, overwrite_edge_ids=False))
+                        add_edge_id=True, overwrite_edge_ids=False,
+                        pre_merge_mapping_file_path=str(tmp_path / 'mapping.jsonl')))
 
 
 def preserve_merge_no_original_ids_test(graph_merger: GraphMerger):
@@ -628,7 +632,8 @@ def test_preserve_merge_no_original_ids_in_memory():
 def test_preserve_merge_no_original_ids_on_disk(tmp_path):
     preserve_merge_no_original_ids_test(
         DiskGraphMerger(temp_directory=str(tmp_path), chunk_size=4,
-                        add_edge_id=True, overwrite_edge_ids=False))
+                        add_edge_id=True, overwrite_edge_ids=False,
+                        pre_merge_mapping_file_path=str(tmp_path / 'mapping.jsonl')))
 
 
 def preserve_flag_ignored_without_add_edge_id_test(graph_merger: GraphMerger):


### PR DESCRIPTION
### Metadata and Merging Improvements 

**Normalization metadata by prefix** 
KGXFileNormalizer now computes and records per-curie-prefix normalization stats (succeeded, failed, total, success_rate, normalized_to), sorted by prevalence, under normalization_metadata. Logs warnings on prefixes below 50% success and logs errors on prefixes that fail outright.

**Edge-id preservation and pre-merge mapping** 
New overwrite_edge_ids flag on GraphSpec (default True, preserves existing behavior). When add_edge_id=True and overwrite_edge_ids=False, unmerged edges keep their original ids, and merged edges get the generated merge key as their new id while the mapping from new id → original pre-merge ids is recorded. DiskGraphMerger streams this mapping to a file as merges finalize instead of buffering it in memory. 

**Dict-shaped biolink slot merging** 
entity_merging_function now merges dict-valued slots (e.g. has_supporting_study_result) instead of silently keeping entity_1's dict. 

**Truthy-prefer scalar collision policy** 
Scalar/scalar merges now prefer the truthy value: falsy values (None, 0, "", False) lose to any populated value on the other side. Only two genuinely different truthy values count as a collision. Also fixed a latent bug where a None in entity_2 could clobber an existing value in entity_1.

**Merge warnings in merge_metadata** 
Collisions surface as metadata and logs: merge_metadata['merge_warnings'] contains mismatched_properties (a dict slot on one side, non-dict on the other) and dropped_properties (genuine collisions). Collected per merger, flushed at generator completion, unioned across node and edge mergers.  