### PR TITLE
Normalization and Merging Versioning 

### DIFF
--- a/orion/__init__.py
+++ b/orion/__init__.py
@@ -3,8 +3,9 @@ from orion.kgx_file_merger import KGXFileMerger
 from orion.kgxmodel import GraphSpec, SubGraphSource
 from orion.kgx_metadata import KGXGraphMetadata, KGXKnowledgeSource, generate_schema
 from orion.meta_kg import MetaKnowledgeGraphBuilder
+from orion.merging import MERGING_CODE_VERSION
 from orion.kgx_file_normalizer import KGXFileNormalizer
-from orion.normalization import NodeNormalizer, NormalizationScheme
+from orion.normalization import NodeNormalizer, NormalizationScheme, NORMALIZATION_CODE_VERSION
 
 __all__ = [
     "KGXFileMerger",
@@ -12,5 +13,6 @@ __all__ = [
     "KGXGraphMetadata", "KGXKnowledgeSource", "generate_schema",
     "MetaKnowledgeGraphBuilder",
     "KGXFileNormalizer",
-    "NodeNormalizer", "NormalizationScheme",
+    "NodeNormalizer", "NormalizationScheme", "NORMALIZATION_CODE_VERSION",
+    "MERGING_CODE_VERSION"
 ]

--- a/orion/biolink_utils.py
+++ b/orion/biolink_utils.py
@@ -1,11 +1,11 @@
 import requests
 import yaml
-import os
 
 from bmt import Toolkit
 from requests.adapters import HTTPAdapter, Retry
 from functools import cache
 
+from orion.biolink_constants import NAMED_THING
 from orion.config import config
 
 BIOLINK_MODEL_VERSION = config.BL_VERSION
@@ -60,6 +60,12 @@ class BiolinkUtils:
             ancestry_set = ancestry_set.union(ancestors)
         leaf_set = biolink_concepts - ancestry_set - unknown_elements
         return leaf_set
+
+    def get_valid_node_types(self) -> frozenset:
+        """
+        Return the set of CURIE-formatted biolink categories (descendants of biolink:NamedThing, inclusive).
+        """
+        return frozenset(self.toolkit.get_descendants(NAMED_THING, formatted=True, reflexive=True))
 
     def invert_predicate(self, biolink_predicate):
         """Given a biolink predicate, find its inverse, return None if one does not exist"""

--- a/orion/build_manager.py
+++ b/orion/build_manager.py
@@ -19,7 +19,7 @@ from orion.kgx_validation import validate_graph
 from orion.neo4j_tools import create_neo4j_dump
 from orion.memgraph_tools import create_memgraph_dump
 from orion.kgxmodel import GraphSpec, SubGraphSource, DataSource
-from orion.normalization import NORMALIZATION_CODE_VERSION, NormalizationScheme
+from orion.normalization import NormalizationScheme, get_current_node_norm_version
 from orion.metadata import Metadata, GraphMetadata, SourceMetadata
 from orion.supplementation import SequenceVariantSupplementation
 from orion.meta_kg import MetaKnowledgeGraphBuilder, META_KG_FILENAME, TEST_DATA_FILENAME, EXAMPLE_DATA_FILENAME
@@ -584,7 +584,7 @@ class GraphBuilder:
                 if edge_id_type is not None and add_edge_id is None or add_edge_id is False:
                     add_edge_id = True
                 if graph_wide_node_norm_version == 'latest':
-                    graph_wide_node_norm_version = self.ingest_pipeline.get_latest_node_normalization_version()
+                    graph_wide_node_norm_version = get_current_node_norm_version()
                 if graph_wide_edge_norm_version == 'latest':
                     graph_wide_edge_norm_version = self.ingest_pipeline.get_latest_edge_normalization_version()
 
@@ -653,14 +653,11 @@ class GraphBuilder:
 
         # supplementation and normalization code version cannot be specified, set them to the current version
         supplementation_version = SequenceVariantSupplementation.SUPPLEMENTATION_VERSION
-        normalization_code_version = NORMALIZATION_CODE_VERSION
 
-        # if normalization versions are not specified, set them to the current latest
+        # if versions are not specified, set them to the current latest
         # source_version is intentionally not handled here because we want to do it lazily and avoid if not needed
         if not parsing_version or parsing_version == 'latest':
             parsing_version = self.ingest_pipeline.get_latest_parsing_version(source_id)
-        if not node_normalization_version or node_normalization_version == 'latest':
-            node_normalization_version = self.ingest_pipeline.get_latest_node_normalization_version()
         if not edge_normalization_version or edge_normalization_version == 'latest':
             edge_normalization_version = self.ingest_pipeline.get_latest_edge_normalization_version()
 
@@ -674,7 +671,6 @@ class GraphBuilder:
 
         normalization_scheme = NormalizationScheme(node_normalization_version=node_normalization_version,
                                                    edge_normalization_version=edge_normalization_version,
-                                                   normalization_code_version=normalization_code_version,
                                                    strict=strict_normalization,
                                                    conflation=conflation)
         data_source = DataSource(id=source_id,

--- a/orion/ingest_pipeline.py
+++ b/orion/ingest_pipeline.py
@@ -47,7 +47,6 @@ class IngestPipeline:
         self.latest_source_version_lookup = {}
         self.latest_parsing_version_lookup = {}
         # placeholders for lazy loading
-        self.latest_node_normalization_version = None
         self.latest_edge_normalization_version = None
         self.latest_supplementation_version = None
 

--- a/orion/ingest_pipeline.py
+++ b/orion/ingest_pipeline.py
@@ -77,12 +77,8 @@ class IngestPipeline:
             return False
 
         if not normalization_scheme:
-            logger.debug(f"No normalization scheme provided, using defaults/latest...")
+            logger.debug(f"No normalization scheme provided, using defaults...")
             normalization_scheme = NormalizationScheme()
-        if normalization_scheme.node_normalization_version == 'latest':
-            normalization_scheme.node_normalization_version = self.get_latest_node_normalization_version()
-        if normalization_scheme.edge_normalization_version == 'latest':
-            normalization_scheme.edge_normalization_version = self.get_latest_edge_normalization_version()
 
         if not self.run_normalization_stage(source_id,
                                             source_version,
@@ -380,14 +376,6 @@ class IngestPipeline:
                                                           normalization_error=repr(e),
                                                           normalization_time=current_time)
             return False
-
-    def get_latest_node_normalization_version(self):
-        if self.latest_node_normalization_version is not None:
-            return self.latest_node_normalization_version
-        node_normalizer = NodeNormalizer()
-        node_norm_version = node_normalizer.get_current_node_norm_version()
-        self.latest_node_normalization_version = node_norm_version
-        return node_norm_version
 
     def get_latest_edge_normalization_version(self):
         if self.latest_edge_normalization_version is not None:

--- a/orion/kgx_file_merger.py
+++ b/orion/kgx_file_merger.py
@@ -7,7 +7,7 @@ from orion.utils import quick_jsonl_file_iterator
 from orion.logging import get_orion_logger
 from orion.kgxmodel import GraphSpec, GraphSource, SubGraphSource
 from orion.biolink_constants import SUBJECT_ID, OBJECT_ID
-from orion.merging import GraphMerger, DiskGraphMerger, MemoryGraphMerger
+from orion.merging import GraphMerger, DiskGraphMerger, MemoryGraphMerger, MERGING_CODE_VERSION
 from orion.ingest_pipeline import RESOURCE_HOGS
 
 logger = get_orion_logger("orion.kgx_file_merger")
@@ -242,6 +242,7 @@ class KGXFileMerger:
     @staticmethod
     def init_merge_metadata():
         return {'sources': {},
+                'merging_code_version': MERGING_CODE_VERSION,
                 'merged_nodes': 0,
                 'merged_edges': 0,
                 'merge_warnings': {'mismatched_properties': [],

--- a/orion/kgx_file_normalizer.py
+++ b/orion/kgx_file_normalizer.py
@@ -67,7 +67,11 @@ class KGXFileNormalizer:
                                                   strict_normalization=normalization_scheme.strict,
                                                   conflate_node_types=normalization_scheme.conflation,
                                                   biolink_version=normalization_scheme.edge_normalization_version)
-            self.edge_normalizer = EdgeNormalizer(edge_normalization_version=normalization_scheme.edge_normalization_version)
+            # when predicates are pre-normalized we never hit the edge normalization (bl_lookup) service
+            if self.predicates_pre_normalized:
+                self.edge_normalizer = None
+            else:
+                self.edge_normalizer = EdgeNormalizer(edge_normalization_version=normalization_scheme.edge_normalization_version)
         except Exception as e:
             raise NormalizationFailedError(error_message=repr(e), actual_error=e)
 
@@ -226,7 +230,7 @@ class KGXFileNormalizer:
         subclass_loops_removed = 0
 
         node_norm_lookup = self.node_normalizer.node_normalization_lookup
-        edge_norm_lookup = self.edge_normalizer.edge_normalization_lookup
+        edge_norm_lookup = self.edge_normalizer.edge_normalization_lookup if self.edge_normalizer else {}
         edge_norm_failures = set()
 
         try:
@@ -332,21 +336,22 @@ class KGXFileNormalizer:
             norm_error_msg = f'Error normalizing edges file {self.source_edges_file_path}'
             raise NormalizationFailedError(error_message=norm_error_msg, actual_error=e)
 
-        try:
-            logger.debug(f'Writing predicate map to file...')
-            edge_norm_json = {}
-            for original_predicate, edge_normalization in edge_norm_lookup.items():
-                edge_norm_json[original_predicate] = edge_normalization.__dict__
-            predicate_map_info = {'predicate_map': edge_norm_json,
-                                  'predicate_norm_failures': list(edge_norm_failures)}
-            with open(self.edge_norm_predicate_map_file_path, "w") as predicate_map_file:
-                json.dump(predicate_map_info, predicate_map_file, sort_keys=True, indent=4)
-        except OSError as e:
-            norm_error_msg = f'Error writing edge predicate map file {self.edge_norm_predicate_map_file_path}'
-            raise NormalizationFailedError(error_message=norm_error_msg, actual_error=e)
+        if not self.predicates_pre_normalized:
+            try:
+                logger.debug(f'Writing predicate map to file...')
+                edge_norm_json = {}
+                for original_predicate, edge_normalization in edge_norm_lookup.items():
+                    edge_norm_json[original_predicate] = edge_normalization.__dict__
+                predicate_map_info = {'predicate_map': edge_norm_json,
+                                      'predicate_norm_failures': list(edge_norm_failures)}
+                with open(self.edge_norm_predicate_map_file_path, "w") as predicate_map_file:
+                    json.dump(predicate_map_info, predicate_map_file, sort_keys=True, indent=4)
+            except OSError as e:
+                norm_error_msg = f'Error writing edge predicate map file {self.edge_norm_predicate_map_file_path}'
+                raise NormalizationFailedError(error_message=norm_error_msg, actual_error=e)
 
         self.normalization_metadata.update({
-            'biolink_version': self.edge_normalizer.edge_norm_version,
+            'biolink_version': self.normalization_scheme.edge_normalization_version,
             'source_edges': number_of_source_edges,
             'edges_failed_due_to_nodes': edges_failed_due_to_nodes,
             # these keep track of how many edges merged into another, or split into multiple edges

--- a/orion/kgx_file_normalizer.py
+++ b/orion/kgx_file_normalizer.py
@@ -63,15 +63,15 @@ class KGXFileNormalizer:
         # instances of the normalization service wrappers
         # strict normalization flag tells normalizer to throw away any nodes that don't normalize
         try:
-            self.node_normalizer = NodeNormalizer(node_normalization_version=normalization_scheme.node_normalization_version,
-                                                  strict_normalization=normalization_scheme.strict,
-                                                  conflate_node_types=normalization_scheme.conflation,
-                                                  biolink_version=normalization_scheme.edge_normalization_version)
+            self.node_normalizer = NodeNormalizer(node_normalization_version=self.normalization_scheme.node_normalization_version,
+                                                  strict_normalization=self.normalization_scheme.strict,
+                                                  conflate_node_types=self.normalization_scheme.conflation,
+                                                  biolink_version=self.normalization_scheme.edge_normalization_version)
             # when predicates are pre-normalized we never hit the edge normalization (bl_lookup) service
             if self.predicates_pre_normalized:
                 self.edge_normalizer = None
             else:
-                self.edge_normalizer = EdgeNormalizer(edge_normalization_version=normalization_scheme.edge_normalization_version)
+                self.edge_normalizer = EdgeNormalizer(edge_normalization_version=self.normalization_scheme.edge_normalization_version)
         except Exception as e:
             raise NormalizationFailedError(error_message=repr(e), actual_error=e)
 

--- a/orion/kgx_file_normalizer.py
+++ b/orion/kgx_file_normalizer.py
@@ -39,9 +39,7 @@ class KGXFileNormalizer:
                  default_provenance: str = None,
                  process_in_memory: bool = True,
                  preserve_unconnected_nodes: bool = False):
-        if not normalization_scheme:
-            normalization_scheme = NormalizationScheme()
-        self.normalization_scheme = normalization_scheme
+        self.normalization_scheme = normalization_scheme if normalization_scheme is not None else NormalizationScheme()
         self.source_nodes_file_path = source_nodes_file_path
         self.nodes_output_file_path = nodes_output_file_path
         self.node_norm_map_file_path = node_norm_map_file_path
@@ -60,8 +58,7 @@ class KGXFileNormalizer:
         self.process_in_memory = process_in_memory
         self.preserve_unconnected_nodes = preserve_unconnected_nodes
         self.default_provenance = default_provenance
-        self.normalization_metadata = {'strict': normalization_scheme.strict,
-                                       'conflation': normalization_scheme.conflation}
+        self.normalization_metadata = self.normalization_scheme.get_metadata_representation()
 
         # instances of the normalization service wrappers
         # strict normalization flag tells normalizer to throw away any nodes that don't normalize
@@ -89,10 +86,6 @@ class KGXFileNormalizer:
     # normalize the nodes and write them to the new file
     # also write a file with the node ids that did not successfully normalize
     def normalize_node_file(self):
-
-        # get the current node normalizer version
-        node_norm_version = self.node_normalizer.get_current_node_norm_version()
-        self.normalization_metadata['node_norm_version'] = node_norm_version
 
         regular_nodes_pre_norm = 0
         regular_nodes_post_norm = 0

--- a/orion/kgx_metadata.py
+++ b/orion/kgx_metadata.py
@@ -246,8 +246,8 @@ def sort_dict_by_values(dict_to_sort):
 
 
 def generate_schema(nodes_file_path: str,
-                    edges_file_path: str,
-                    biolink_version: str):
+                    edges_file_path: str = None,
+                    biolink_version: str = None):
 
     bl_utils = BiolinkUtils(biolink_version=biolink_version)
 
@@ -275,7 +275,8 @@ def generate_schema(nodes_file_path: str,
     # Edges
     core_attributes = {SUBJECT_ID, PREDICATE, OBJECT_ID, PRIMARY_KNOWLEDGE_SOURCE, "sources"}
     edges = defaultdict(KGXEdgeType)
-    for edge in quick_jsonl_file_iterator(edges_file_path):
+    edge_iterator = quick_jsonl_file_iterator(edges_file_path) if edges_file_path else iter(())
+    for edge in edge_iterator:
         # get references to some edge properties
         subject_id = edge[SUBJECT_ID]
         object_id = edge[OBJECT_ID]

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -36,7 +36,7 @@ def flush_merge_warnings():
                        f'{mismatched}. Some instances were dictionaries and some were not. Mismatches were discarded.')
     if dropped:
         logger.warning(f'Property value collisions encountered while merging properties: '
-                       f'{dropped}. Values were discarded from merged edges.')
+                       f'{dropped}. Some conflicting values were discarded from merged edges.')
     _mismatched_dict_properties.clear()
     _dropped_properties.clear()
     return {'mismatched_properties': mismatched, 'dropped_properties': dropped}

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -20,6 +20,8 @@ bmt = BiolinkUtils()
 
 logger = get_orion_logger("orion.merging")
 
+MERGING_CODE_VERSION = '2.0.0'
+
 # mismatches where one entity has a dict for a property and another has another type.
 _mismatched_dict_properties = set()
 # properties where two entities had different values that could not be reconciled.

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -33,10 +33,10 @@ def flush_merge_warnings():
     dropped = sorted(_dropped_properties)
     if mismatched:
         logger.warning(f'Mismatched types encountered while merging properties: '
-                       f'{mismatched}. entity_1 values were kept.')
+                       f'{mismatched}. Some instances were dictionaries are some were not. Mismatches were discarded.')
     if dropped:
         logger.warning(f'Property value collisions encountered while merging properties: '
-                       f'{dropped}. entity_1 values were kept, entity_2 values were dropped.')
+                       f'{dropped}. Values were discarded from merged edges.')
     _mismatched_dict_properties.clear()
     _dropped_properties.clear()
     return {'mismatched_properties': mismatched, 'dropped_properties': dropped}

--- a/orion/merging.py
+++ b/orion/merging.py
@@ -33,7 +33,7 @@ def flush_merge_warnings():
     dropped = sorted(_dropped_properties)
     if mismatched:
         logger.warning(f'Mismatched types encountered while merging properties: '
-                       f'{mismatched}. Some instances were dictionaries are some were not. Mismatches were discarded.')
+                       f'{mismatched}. Some instances were dictionaries and some were not. Mismatches were discarded.')
     if dropped:
         logger.warning(f'Property value collisions encountered while merging properties: '
                        f'{dropped}. Values were discarded from merged edges.')

--- a/orion/metadata.py
+++ b/orion/metadata.py
@@ -2,8 +2,6 @@ import os
 import json
 from xxhash import xxh64_hexdigest
 
-from orion.normalization import NormalizationScheme
-
 
 class Metadata:
 

--- a/orion/metadata.py
+++ b/orion/metadata.py
@@ -1,4 +1,3 @@
-
 import os
 import json
 from xxhash import xxh64_hexdigest
@@ -248,7 +247,6 @@ class SourceMetadata(Metadata):
     def update_normalization_metadata(self,
                                       parsing_version: str,
                                       normalization_version: str,
-                                      normalization_scheme: NormalizationScheme = None,
                                       normalization_status: str = None,
                                       normalization_info: dict = None,
                                       normalization_time: str = None,
@@ -256,7 +254,6 @@ class SourceMetadata(Metadata):
         if normalization_version not in self.metadata['parsings'][parsing_version]['normalizations']:
             normalization_dict = {
                 'normalization_status': self.NOT_STARTED,
-                'normalization_metadata': None,
                 'normalization_time': None,
                 'supplementations': dict()
             }
@@ -267,11 +264,6 @@ class SourceMetadata(Metadata):
             normalization_dict['normalization_status'] = normalization_status
         if normalization_info:
             normalization_dict['normalization_info'] = normalization_info
-        if normalization_scheme:
-            normalization_dict['node_normalization_version'] = normalization_scheme.node_normalization_version
-            normalization_dict['edge_normalization_version'] = normalization_scheme.edge_normalization_version
-            normalization_dict['strict_normalization'] = normalization_scheme.strict
-            normalization_dict['conflation'] = normalization_scheme.conflation
         if normalization_time:
             normalization_dict['normalization_time'] = normalization_time
         if normalization_error:

--- a/orion/normalization.py
+++ b/orion/normalization.py
@@ -53,9 +53,9 @@ class NormalizationScheme:
             self.babel_version = get_current_babel_version()
 
     def get_composite_normalization_version(self):
-        composite_normalization_version = f'{self.babel_version}_' \
-                                f'{self.edge_normalization_version}_{self.normalization_code_version}_' \
-                                f'{self.node_normalization_version}'
+        composite_normalization_version = f'{self.babel_version}_{self.node_normalization_version}_' \
+                                f'{self.edge_normalization_version}_{self.normalization_code_version}'
+
         if self.conflation:
             composite_normalization_version += '_conflated'
         if self.strict:

--- a/orion/normalization.py
+++ b/orion/normalization.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from robokop_genetics.genetics_normalization import GeneticsNormalizer
 from orion.biolink_constants import *
+from orion.biolink_utils import BiolinkUtils
 from orion.logging import get_orion_logger
 from orion.config import config
 
@@ -92,7 +93,7 @@ class NodeNormalizer:
 
     def __init__(self,
                  node_normalization_version: str = 'latest',
-                 biolink_version: str = 'latest',
+                 biolink_version: str = None,
                  strict_normalization: bool = True,
                  conflate_node_types: bool = False,
                  include_taxa: bool = False):
@@ -155,8 +156,7 @@ class NodeNormalizer:
         # look up all valid biolink node types if needed
         # this is used when strict normalization is off to ensure only valid types go into the graph as NODE_TYPES
         if not self.strict_normalization and not self.biolink_compliant_node_types:
-            biolink_lookup = EdgeNormalizer(edge_normalization_version=self.biolink_version)
-            self.biolink_compliant_node_types = biolink_lookup.get_valid_node_types()
+            self.biolink_compliant_node_types = BiolinkUtils(biolink_version=self.biolink_version).get_valid_node_types()
 
         # make a list of the node ids, we used to deduplicate here, but now we expect the list to be unique ids
         to_normalize: list = [node['id'] for node in node_list]
@@ -536,25 +536,6 @@ class EdgeNormalizer:
             # this shouldn't happen, raise an exception
             resp.raise_for_status()
 
-    def check_node_type_valid(self, node_type: str):
-        if node_type in self.get_valid_node_types():
-            return True
-        else:
-            return False
-
-    def get_valid_node_types(self):
-        # call the descendants endpoint with the root node type
-        edge_norm_descendants_url = f'{self.edge_norm_endpoint}/bl/{NAMED_THING}/descendants?version={self.edge_norm_version}'
-        resp: requests.models.Response = requests.get(edge_norm_descendants_url)
-
-        # did we get a good status code
-        if resp.status_code == 200:
-            # parse json
-            descendants = resp.json()
-            return descendants  # array of descendants
-        else:
-            # this shouldn't happen, raise an exception
-            resp.raise_for_status()
 
 
 NAME_RESOLVER_URL = config.NAMERES_URL

--- a/orion/normalization.py
+++ b/orion/normalization.py
@@ -77,7 +77,6 @@ class NormalizationFailedError(Exception):
         self.actual_error = actual_error
 
 
-
 class NodeNormalizer:
     """
     Class that contains methods relating to node normalization of KGX data.
@@ -363,7 +362,6 @@ class NodeNormalizer:
                 self.node_normalization_lookup[variant_id] = split_ids
 
         return variant_nodes
-
 
 
     @staticmethod

--- a/orion/normalization.py
+++ b/orion/normalization.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import functools
 import requests
 import time
 
@@ -13,7 +13,22 @@ from orion.config import config
 
 logger = get_orion_logger("orion.normalization")
 
-NORMALIZATION_CODE_VERSION = '1.4'
+NORMALIZATION_CODE_VERSION = '1.4.0'
+
+
+@functools.lru_cache(maxsize=1)
+def get_current_node_norm_version():
+    """Retrieve the current version of the Node Normalizer API."""
+    resp = requests.get(f'{config.NODE_NORMALIZATION_URL}/openapi.json')
+    resp.raise_for_status()
+    return resp.json()['info']['version']
+
+@functools.lru_cache(maxsize=1)
+def get_current_babel_version():
+    """Retrieve the version of Babel the Node Normalizer is currently backed by"""
+    resp = requests.get(f'{config.NODE_NORMALIZATION_URL}/status')
+    resp.raise_for_status()
+    return resp.json()['babel_version']
 
 # node property name for node types that did not normalize
 CUSTOM_NODE_TYPES = 'custom_node_types'
@@ -24,15 +39,23 @@ FALLBACK_EDGE_PREDICATE = 'biolink:related_to'
 
 @dataclass
 class NormalizationScheme:
-    node_normalization_version: str = 'latest'
+    node_normalization_version: str = None
     edge_normalization_version: str = 'latest'
+    babel_version: str = None
     normalization_code_version: str = NORMALIZATION_CODE_VERSION
     strict: bool = True
     conflation: bool = False
 
+    def __post_init__(self):
+        if self.node_normalization_version is None:
+            self.node_normalization_version = get_current_node_norm_version()
+        if self.babel_version is None:
+            self.babel_version = get_current_babel_version()
+
     def get_composite_normalization_version(self):
-        composite_normalization_version = f'{self.node_normalization_version}_' \
-                                f'{self.edge_normalization_version}_{self.normalization_code_version}'
+        composite_normalization_version = f'{self.babel_version}_' \
+                                f'{self.edge_normalization_version}_{self.normalization_code_version}_' \
+                                f'{self.node_normalization_version}'
         if self.conflation:
             composite_normalization_version += '_conflated'
         if self.strict:
@@ -42,6 +65,7 @@ class NormalizationScheme:
     def get_metadata_representation(self):
         return {'node_normalization_version': self.node_normalization_version,
                 'edge_normalization_version': self.edge_normalization_version,
+                'babel_version': self.babel_version,
                 'normalization_code_version': self.normalization_code_version,
                 'conflation': self.conflation,
                 'strict': self.strict}
@@ -52,7 +76,6 @@ class NormalizationFailedError(Exception):
         self.error_message = error_message
         self.actual_error = actual_error
 
-NODE_NORMALIZATION_URL = config.NODE_NORMALIZATION_URL
 
 
 class NodeNormalizer:
@@ -100,7 +123,7 @@ class NodeNormalizer:
 
     def hit_node_norm_service(self, curies, retries=0):
         resp: requests.models.Response = \
-            self.requests_session.post(f'{NODE_NORMALIZATION_URL}/get_normalized_nodes',
+            self.requests_session.post(f'{config.NODE_NORMALIZATION_URL}/get_normalized_nodes',
                                        json={'curies': curies,
                                              'conflate': self.conflate_node_types,
                                              'drug_chemical_conflate': self.conflate_node_types,
@@ -112,7 +135,7 @@ class NodeNormalizer:
             if response_json:
                 return response_json
             else:
-                error_message = f"Node Normalization service {NODE_NORMALIZATION_URL} returned 200 " \
+                error_message = f"Node Normalization service {config.NODE_NORMALIZATION_URL} returned 200 " \
                                 f"but with an empty result for (curies: {curies})"
                 raise NormalizationFailedError(error_message=error_message)
         else:
@@ -341,18 +364,6 @@ class NodeNormalizer:
 
         return variant_nodes
 
-    def get_current_node_norm_version(self):
-        """
-        Retrieves the current production version from the node normalization service
-        """
-        # hit the node norm status endpoint
-        node_norm_status_url = f'{NODE_NORMALIZATION_URL}/status'
-        resp: requests.models.Response = requests.get(node_norm_status_url)
-        resp.raise_for_status()
-        status: dict = resp.json()
-        # extract the version
-        node_norm_version = status['babel_version']
-        return node_norm_version
 
 
     @staticmethod

--- a/parsers/LitCoin/src/bagel/bagel.py
+++ b/parsers/LitCoin/src/bagel/bagel.py
@@ -2,10 +2,11 @@
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+from orion.config import config
+
 from parsers.LitCoin.src.NER.nameres import NameResNEREngine
 from parsers.LitCoin.src.NER.sapbert import SAPBERTNEREngine
 from parsers.LitCoin.src.bagel.bagel_gpt import ask_classes_and_descriptions, LLM_RESULTS
-from orion.normalization import NODE_NORMALIZATION_URL
 
 
 BAGEL_SUBJECT_SYN_TYPE = 'subject_bagel_syn_type'
@@ -119,7 +120,7 @@ def augment_results(terms, nameres, taxes):
     augs = nameres.reverse_lookup(curies)
     for curie in augs:
         terms[curie].update(augs[curie])
-        resp = requests.get(f"{NODE_NORMALIZATION_URL}/get_normalized_nodes?curie="+curie+"&conflate=true&drug_chemical_conflate=true&description=true")
+        resp = requests.get(f"{config.NODE_NORMALIZATION_URL}/get_normalized_nodes?curie="+curie+"&conflate=true&drug_chemical_conflate=true&description=true")
         if resp.status_code == 200:
             result = resp.json()
             try:
@@ -131,7 +132,7 @@ def augment_results(terms, nameres, taxes):
         if len(annotation["taxa"]) > 0:
             tax_id = annotation["taxa"][0]
             if tax_id not in taxes:
-                resp = requests.get(f"{NODE_NORMALIZATION_URL}/get_normalized_nodes?curie="+tax_id)
+                resp = requests.get(f"{config.NODE_NORMALIZATION_URL}/get_normalized_nodes?curie="+tax_id)
                 if resp.status_code == 200:
                     result = resp.json()
                     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "robokop-orion"
-version = "1.3.0"
+version = "1.3.1"
 description = "ORION ingests data from knowledge bases and converts it into interoperable Biolink Model knowledge graphs."
 license = "MIT"
 license-files = ["LICEN[CS]E*"]

--- a/tests/test_kgx_file_normalizer.py
+++ b/tests/test_kgx_file_normalizer.py
@@ -1,0 +1,273 @@
+import os
+from urllib.parse import parse_qs, urlparse
+
+import jsonlines
+import pytest
+
+from orion.biolink_constants import NAMED_THING, GENE, NODE_TYPES, SUBJECT_ID, OBJECT_ID, PREDICATE
+from orion.kgx_file_normalizer import KGXFileNormalizer
+
+
+NODE_NORM_RESPONSE = {
+    'HGNC:7432': {
+        'id': {
+            'identifier': 'NCBIGene:4522',
+            'label': 'MTHFD1',
+            'description': 'methylenetetrahydrofolate dehydrogenase, cyclohydrolase and '
+                           'formyltetrahydrofolate synthetase 1',
+        },
+        'type': [
+            'biolink:Gene',
+            'biolink:GeneOrGeneProduct',
+            'biolink:GenomicEntity',
+            'biolink:ChemicalEntityOrGeneOrGeneProduct',
+            'biolink:PhysicalEssence',
+            'biolink:OntologyClass',
+            'biolink:BiologicalEntity',
+            'biolink:ThingWithTaxon',
+            'biolink:NamedThing',
+            'biolink:PhysicalEssenceOrOccurrent',
+            'biolink:MacromolecularMachineMixin',
+        ],
+        'equivalent_identifiers': [
+            {'identifier': 'NCBIGene:4522', 'label': 'MTHFD1'},
+            {'identifier': 'ENSEMBL:ENSG00000100714'},
+            {'identifier': 'HGNC:7432', 'label': 'MTHFD1'},
+            {'identifier': 'OMIM:172460'},
+            {'identifier': 'UMLS:C1417420', 'label': 'MTHFD1 gene'},
+        ],
+        'information_content': 84.8,
+    },
+    'CHEBI:33551': {
+        'id': {
+            'identifier': 'CHEBI:33551',
+            'label': 'organosulfonic acid',
+            'description': 'An organic derivative of sulfonic acid in which the sulfo group '
+                           'is linked directly to carbon.',
+        },
+        'type': [
+            'biolink:SmallMolecule',
+            'biolink:MolecularEntity',
+            'biolink:ChemicalEntity',
+            'biolink:PhysicalEssence',
+            'biolink:ChemicalOrDrugOrTreatment',
+            'biolink:ChemicalEntityOrGeneOrGeneProduct',
+            'biolink:ChemicalEntityOrProteinOrPolypeptide',
+            'biolink:NamedThing',
+            'biolink:PhysicalEssenceOrOccurrent',
+        ],
+        'equivalent_identifiers': [
+            {'identifier': 'CHEBI:33551', 'label': 'organosulfonic acid'},
+        ],
+        'information_content': 55.7,
+    },
+    'CHEBI:15377': {
+        'id': {'identifier': 'CHEBI:15377', 'label': 'water'},
+        'type': ['biolink:SmallMolecule', 'biolink:ChemicalEntity', 'biolink:NamedThing'],
+        'equivalent_identifiers': [{'identifier': 'CHEBI:15377', 'label': 'water'}],
+        'information_content': 40.0,
+    },
+}
+
+PREDICATE_MAP = {
+    'SEMMEDDB:CAUSES': {'predicate': 'biolink:causes', 'identifier': 'biolink:causes'},
+    # biolink:affected_by normalizes to biolink:affects with the edge direction inverted
+    'biolink:affected_by': {'predicate': 'biolink:affects', 'identifier': 'biolink:affects',
+                            'inverted': True},
+}
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f'status {self.status_code}')
+
+
+@pytest.fixture
+def mock_normalization(monkeypatch):
+    """Stub every HTTP touchpoint in orion.normalization and track edge-norm calls."""
+    edge_norm_calls = []
+
+    monkeypatch.setattr('orion.normalization.get_current_node_norm_version', lambda: '2.4.1')
+    monkeypatch.setattr('orion.normalization.get_current_babel_version', lambda: '2025sep1')
+
+    def fake_hit_node_norm(self, curies, retries=0):
+        return {curie: NODE_NORM_RESPONSE.get(curie) for curie in curies}
+    monkeypatch.setattr('orion.normalization.NodeNormalizer.hit_node_norm_service', fake_hit_node_norm)
+
+    monkeypatch.setattr('orion.normalization.EdgeNormalizer.get_available_versions',
+                        lambda self: ['v4.3.7', 'v4.3.6', 'v4.2.6-rc5', 'latest'])
+
+    def fake_requests_get(url, *args, **kwargs):
+        if '/resolve_predicate' in url:
+            edge_norm_calls.append(url)
+            query = parse_qs(urlparse(url).query)
+            predicates = query.get('predicate', [])
+            result = {p: PREDICATE_MAP.get(p, {'predicate': 'biolink:related_to'})
+                      for p in predicates}
+            return _FakeResponse(200, result)
+        raise RuntimeError(f'Unexpected requests.get call in test: {url}')
+    monkeypatch.setattr('orion.normalization.requests.get', fake_requests_get)
+
+    return {'edge_norm_calls': edge_norm_calls}
+
+
+def _write_jsonl(path, items):
+    with jsonlines.open(path, mode='w') as writer:
+        for item in items:
+            writer.write(item)
+
+
+def _make_paths(tmp_path):
+    return {
+        'source_nodes_file_path': str(tmp_path / 'source_nodes.jsonl'),
+        'nodes_output_file_path': str(tmp_path / 'nodes.jsonl'),
+        'node_norm_map_file_path': str(tmp_path / 'node_norm_map.json'),
+        'node_norm_failures_file_path': str(tmp_path / 'node_norm_failures.txt'),
+        'source_edges_file_path': str(tmp_path / 'source_edges.jsonl'),
+        'edges_output_file_path': str(tmp_path / 'edges.jsonl'),
+        'edge_norm_predicate_map_file_path': str(tmp_path / 'edge_norm_predicate_map.json'),
+    }
+
+
+def test_kgx_file_normalizer_basic(tmp_path, mock_normalization):
+    paths = _make_paths(tmp_path)
+    nodes = [
+        {'id': 'HGNC:7432', 'name': 'MTHFD1', NODE_TYPES: [GENE]},
+        {'id': 'CHEBI:33551', 'name': '', NODE_TYPES: [NAMED_THING]},
+    ]
+    edges = [
+        {SUBJECT_ID: 'HGNC:7432', OBJECT_ID: 'CHEBI:33551', PREDICATE: 'SEMMEDDB:CAUSES'},
+    ]
+    _write_jsonl(paths['source_nodes_file_path'], nodes)
+    _write_jsonl(paths['source_edges_file_path'], edges)
+
+    normalizer = KGXFileNormalizer(**paths, default_provenance='infores:testing')
+    metadata = normalizer.normalize_kgx_files()
+
+    assert metadata['final_normalized_nodes'] > 0
+    assert metadata['final_normalized_edges'] == 1
+
+    output_edges = list(jsonlines.open(paths['edges_output_file_path']))
+    assert len(output_edges) == 1
+    assert output_edges[0][PREDICATE] == 'biolink:causes'
+    assert output_edges[0][SUBJECT_ID] == 'NCBIGene:4522'
+    assert output_edges[0][OBJECT_ID] == 'CHEBI:33551'
+
+    assert os.path.exists(paths['edge_norm_predicate_map_file_path'])
+    assert mock_normalization['edge_norm_calls'], 'expected at least one bl_lookup call'
+
+
+def test_predicates_pre_normalized_preserves_predicates(tmp_path, mock_normalization):
+    paths = _make_paths(tmp_path)
+    nodes = [
+        {'id': 'HGNC:7432', 'name': 'MTHFD1', NODE_TYPES: [GENE]},
+        {'id': 'CHEBI:33551', 'name': '', NODE_TYPES: [NAMED_THING]},
+    ]
+    # A predicate that bl_lookup would otherwise rewrite to biolink:causes — keeping it verbatim
+    # proves the edge normalization path was skipped.
+    preserved_predicate = 'SEMMEDDB:CAUSES'
+    edges = [
+        {SUBJECT_ID: 'HGNC:7432', OBJECT_ID: 'CHEBI:33551', PREDICATE: preserved_predicate},
+    ]
+    _write_jsonl(paths['source_nodes_file_path'], nodes)
+    _write_jsonl(paths['source_edges_file_path'], edges)
+
+    normalizer = KGXFileNormalizer(**paths,
+                                   default_provenance='infores:testing',
+                                   predicates_pre_normalized=True)
+
+    # no EdgeNormalizer instance — guarantees no bl_lookup calls were made during construction
+    assert normalizer.edge_normalizer is None
+
+    normalizer.normalize_kgx_files()
+
+    output_edges = list(jsonlines.open(paths['edges_output_file_path']))
+    assert len(output_edges) == 1
+    assert output_edges[0][PREDICATE] == preserved_predicate
+
+    # no predicate map file should be written when predicates are pre-normalized
+    assert not os.path.exists(paths['edge_norm_predicate_map_file_path'])
+
+    # and no bl_lookup HTTP calls should have happened at any point
+    assert mock_normalization['edge_norm_calls'] == []
+
+
+def test_unconnected_nodes_are_removed(tmp_path, mock_normalization):
+    paths = _make_paths(tmp_path)
+    nodes = [
+        {'id': 'HGNC:7432', 'name': 'MTHFD1', NODE_TYPES: [GENE]},
+        {'id': 'CHEBI:33551', 'name': '', NODE_TYPES: [NAMED_THING]},
+        # no edge references this node — should be dropped from the output by default
+        {'id': 'CHEBI:15377', 'name': 'water', NODE_TYPES: [NAMED_THING]},
+    ]
+    edges = [
+        {SUBJECT_ID: 'HGNC:7432', OBJECT_ID: 'CHEBI:33551', PREDICATE: 'SEMMEDDB:CAUSES'},
+    ]
+    _write_jsonl(paths['source_nodes_file_path'], nodes)
+    _write_jsonl(paths['source_edges_file_path'], edges)
+
+    normalizer = KGXFileNormalizer(**paths, default_provenance='infores:testing')
+    metadata = normalizer.normalize_kgx_files()
+
+    output_node_ids = {n['id'] for n in jsonlines.open(paths['nodes_output_file_path'])}
+    assert 'CHEBI:15377' not in output_node_ids
+    assert {'NCBIGene:4522', 'CHEBI:33551'} <= output_node_ids
+    assert metadata['unconnected_nodes_removed'] == 1
+
+
+def test_unconnected_nodes_preserved_when_flag_set(tmp_path, mock_normalization):
+    paths = _make_paths(tmp_path)
+    nodes = [
+        {'id': 'HGNC:7432', 'name': 'MTHFD1', NODE_TYPES: [GENE]},
+        {'id': 'CHEBI:33551', 'name': '', NODE_TYPES: [NAMED_THING]},
+        {'id': 'CHEBI:15377', 'name': 'water', NODE_TYPES: [NAMED_THING]},
+    ]
+    edges = [
+        {SUBJECT_ID: 'HGNC:7432', OBJECT_ID: 'CHEBI:33551', PREDICATE: 'SEMMEDDB:CAUSES'},
+    ]
+    _write_jsonl(paths['source_nodes_file_path'], nodes)
+    _write_jsonl(paths['source_edges_file_path'], edges)
+
+    normalizer = KGXFileNormalizer(**paths,
+                                   default_provenance='infores:testing',
+                                   preserve_unconnected_nodes=True)
+    metadata = normalizer.normalize_kgx_files()
+
+    output_node_ids = {n['id'] for n in jsonlines.open(paths['nodes_output_file_path'])}
+    assert 'CHEBI:15377' in output_node_ids
+    assert metadata['unconnected_nodes_removed'] == 0
+
+
+def test_edge_inversion_swaps_subject_and_object(tmp_path, mock_normalization):
+    paths = _make_paths(tmp_path)
+    nodes = [
+        {'id': 'HGNC:7432', 'name': 'MTHFD1', NODE_TYPES: [GENE]},
+        {'id': 'CHEBI:33551', 'name': '', NODE_TYPES: [NAMED_THING]},
+    ]
+    # biolink:affected_by normalizes to biolink:affects with inverted=True,
+    # so subject and object should swap in the output.
+    edges = [
+        {SUBJECT_ID: 'HGNC:7432', OBJECT_ID: 'CHEBI:33551', PREDICATE: 'biolink:affected_by'},
+    ]
+    _write_jsonl(paths['source_nodes_file_path'], nodes)
+    _write_jsonl(paths['source_edges_file_path'], edges)
+
+    normalizer = KGXFileNormalizer(**paths, default_provenance='infores:testing')
+    normalizer.normalize_kgx_files()
+
+    output_edges = list(jsonlines.open(paths['edges_output_file_path']))
+    assert len(output_edges) == 1
+    edge = output_edges[0]
+    assert edge[PREDICATE] == 'biolink:affects'
+    # original edge was HGNC:7432 -affected_by-> CHEBI:33551
+    # after inversion: CHEBI:33551 -affects-> NCBIGene:4522
+    assert edge[SUBJECT_ID] == 'CHEBI:33551'
+    assert edge[OBJECT_ID] == 'NCBIGene:4522'

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "robokop-orion"
-version = "0.2.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "bmt" },


### PR DESCRIPTION
This reworks how normalization versioning is determined and tracked for dependency and metadata purposes. It adds a version for merging code. It exposes both of those through the public package interface.

- Split babel_version from node_normalization_version in NormalizationScheme and metadata. Previously there was only one field. Now considers both as relevant for normalization updates.
- Exposed a composite version function through NormalizationScheme that can be used for pipeline dependency management. Includes the babel version, node norm version, normalization code, and strict/conflation settings.
- Added MERGING_CODE_VERSION, record it in metadata, expose it through the public interface.
- Decoupled EdgeNormalizer and bl-lookup usage from NodeNormalizer. When predicates_pre_normalized=True, KGXFileNormalizer no longer uses EdgeNormalizer for biolink purposes (moved get_valid_node_types() to BiolinkUtils using bmt).
- Added tests for kgx_file_normalizer.py.

Additionally, changed generate_schema so it works for nodes without an edges file.