### PR TITLE
Logging Rework

### DIFF
--- a/orion/build_manager.py
+++ b/orion/build_manager.py
@@ -722,6 +722,9 @@ class GraphBuilder:
 
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
+
     parser = argparse.ArgumentParser(description="Merge data sources into complete graphs.")
     parser.add_argument('graph_id',
                         help='ID of the graph to build. Must match an ID from the configured Graph Spec.')

--- a/orion/cli/generate_ac_files.py
+++ b/orion/cli/generate_ac_files.py
@@ -2,6 +2,9 @@ import argparse
 from orion.answercoalesce_build import generate_ac_files
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
+
     ap = argparse.ArgumentParser(
         description='Generate node labels, names, links, backlinks, and other AnswerCoalesce files from KGX node/edge files.'
     )

--- a/orion/cli/generate_meta_kg.py
+++ b/orion/cli/generate_meta_kg.py
@@ -3,6 +3,9 @@ import os
 from orion.meta_kg import MetaKnowledgeGraphBuilder, META_KG_FILENAME, TEST_DATA_FILENAME
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
+
     ap = argparse.ArgumentParser(description='Generate MetaKG and test data files '
                                              'from a pair of node and edge jsonl files.')
     ap.add_argument('nodes_filepath')

--- a/orion/cli/generate_redundant_kg.py
+++ b/orion/cli/generate_redundant_kg.py
@@ -3,6 +3,9 @@ from orion.redundant_kg import generate_redundant_kg
                 
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
+
     ap = argparse.ArgumentParser(description='Generate redundant edge files. '
                                              'currently expanding from predicate and qualified_predicate.')
     ap.add_argument('-i', '--infile', help='Input edge file path', required=True)

--- a/orion/cli/memgraph_dump.py
+++ b/orion/cli/memgraph_dump.py
@@ -2,6 +2,8 @@ import argparse
 from orion.memgraph_tools import create_memgraph_dump
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
 
     ap = argparse.ArgumentParser(description='Create memgraph CSV import files from KGX jsonl files.')
     ap.add_argument('nodes_filepath')

--- a/orion/cli/merge_kgs.py
+++ b/orion/cli/merge_kgs.py
@@ -5,6 +5,9 @@ from orion.kgx_file_merger import merge_kgx_files
 
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
+
     ap = argparse.ArgumentParser(description="Given a list of node files and/or a list of edge files "
                                              "in kgx jsonl format, merge them into one node and one edge file.")
     ap.add_argument(

--- a/orion/cli/neo4j_dump.py
+++ b/orion/cli/neo4j_dump.py
@@ -2,6 +2,8 @@ import argparse
 from orion.neo4j_tools import create_neo4j_dump
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
 
     ap = argparse.ArgumentParser(description='Create a neo4j dump from KGX jsonl files.')
     ap.add_argument('nodes_filepath')

--- a/orion/ingest_pipeline.py
+++ b/orion/ingest_pipeline.py
@@ -320,7 +320,6 @@ class IngestPipeline:
         source_metadata = self.get_source_metadata(source_id, source_version)
         source_metadata.update_normalization_metadata(parsing_version,
                                                       composite_normalization_version,
-                                                      normalization_scheme=normalization_scheme,
                                                       normalization_status=SourceMetadata.IN_PROGRESS)
         current_time = datetime.datetime.now().strftime('%m-%d-%y %H:%M:%S')
         try:

--- a/orion/ingest_pipeline.py
+++ b/orion/ingest_pipeline.py
@@ -707,6 +707,9 @@ class IngestPipeline:
 
 
 def main():
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
+
     parser = argparse.ArgumentParser(description="Transform data sources into KGX files.")
     parser.add_argument('data_source',
                         nargs="+",

--- a/orion/kgx_file_converter.py
+++ b/orion/kgx_file_converter.py
@@ -378,6 +378,9 @@ def __convert_to_csv(input_file: str,
 
 
 if __name__ == '__main__':
+    from orion.logging import configure_cli_logging
+    configure_cli_logging()
+
     parser = argparse.ArgumentParser(description='Convert jsonl kgx files to csv neo4j import files')
     parser.add_argument('nodes', help='file with nodes in jsonl format')
     parser.add_argument('edges', help='file with edges in jsonl format')

--- a/orion/kgx_file_normalizer.py
+++ b/orion/kgx_file_normalizer.py
@@ -29,7 +29,7 @@ class KGXFileNormalizer:
                  node_norm_failures_file_path: str,
                  source_edges_file_path: str,
                  edges_output_file_path: str,
-                 edge_norm_predicate_map_file_path: str,
+                 edge_norm_predicate_map_file_path: str = None,
                  normalization_scheme: NormalizationScheme = None,
                  edge_subject_pre_normalized: bool = False,
                  edge_object_pre_normalized: bool = False,

--- a/orion/logging.py
+++ b/orion/logging.py
@@ -5,45 +5,56 @@ from logging.handlers import RotatingFileHandler
 from orion.config import config
 
 
+ORION_LOG_FORMAT = '[%(asctime)s] %(name)s %(levelname)s: %(message)s'
+
+
 def get_orion_logger(name):
-    """
-        Logging utility controlling format and setting initial logging level
-    """
+    """Return a logger for ORION library code.
 
-    # get the logger with the specified name
+    Follows the standard library convention (as used by requests, urllib3, etc.):
+    attaches a NullHandler so importing ORION never produces output or
+    "no handlers could be found" warnings. Applications — including ORION's own
+    CLI entry points via configure_cli_logging() — can apply handler/level
+    configuration which will pick up the logs through propagation.
+    """
     logger = logging.getLogger(name)
-
-    # if it already has handlers, it was already instantiated - return it
-    if logger.hasHandlers():
-        return logger
-
-    formatter = logging.Formatter('%(asctime)-15s - %(funcName)s(): %(message)s')
-
-    level = logging.DEBUG if config.ORION_TEST_MODE else logging.INFO
-    logger.setLevel(level)
-
-    # if ORION_LOGS is set, write logs to files there
-    if config.ORION_LOGS is not None:
-        # create a rotating file handler, 100mb max per file with a max number of 10 files
-        file_handler = RotatingFileHandler(filename=os.path.join(config.ORION_LOGS, name + '.log'), maxBytes=100000000, backupCount=10)
-
-        # set the formatter
-        file_handler.setFormatter(formatter)
-
-        # set the log level
-        file_handler.setLevel(level)
-
-        # add the handler to the logger
-        logger.addHandler(file_handler)
-
-    # create a stream handler as well (default to console/stdout)
-    stream_handler = logging.StreamHandler()
-
-    # set the formatter on the console stream
-    stream_handler.setFormatter(formatter)
-
-    # add the console handler to the logger
-    logger.addHandler(stream_handler)
-
-    # return to the caller
+    if not any(isinstance(h, logging.NullHandler) for h in logger.handlers):
+        logger.addHandler(logging.NullHandler())
     return logger
+
+
+def configure_cli_logging(level=None):
+    """Configure stderr (and optional file) logging on the root logger.
+
+    Intended to be called from ORION CLI entry points (scripts run as __main__).
+    Handlers are attached to the root logger so that every logger tree used by
+    ORION and its parsers (orion.*, parsers.*, etc.) is captured via normal
+    propagation. Safe to call more than once; handlers are added only if absent,
+    and the level is refreshed on each call.
+    """
+    root_logger = logging.getLogger()
+    if level is None:
+        level = logging.DEBUG if config.ORION_TEST_MODE else logging.INFO
+    root_logger.setLevel(level)
+
+    formatter = logging.Formatter(ORION_LOG_FORMAT)
+
+    # type() check (not isinstance): FileHandler and RotatingFileHandler are
+    # subclasses of StreamHandler, but we want to treat console vs file as
+    # distinct cases here.
+    has_stream = any(type(h) is logging.StreamHandler for h in root_logger.handlers)
+    if not has_stream:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
+        root_logger.addHandler(stream_handler)
+
+    if config.ORION_LOGS is not None:
+        has_file = any(isinstance(h, RotatingFileHandler) for h in root_logger.handlers)
+        if not has_file:
+            file_handler = RotatingFileHandler(
+                filename=os.path.join(config.ORION_LOGS, 'orion.log'),
+                maxBytes=100_000_000,
+                backupCount=10,
+            )
+            file_handler.setFormatter(formatter)
+            root_logger.addHandler(file_handler)

--- a/orion/normalization.py
+++ b/orion/normalization.py
@@ -48,9 +48,9 @@ class NormalizationScheme:
     conflation: bool = False
 
     def __post_init__(self):
-        if self.node_normalization_version is None:
+        if self.node_normalization_version in (None, 'latest'):
             self.node_normalization_version = get_current_node_norm_version()
-        if self.babel_version is None:
+        if self.babel_version in (None, 'latest'):
             self.babel_version = get_current_babel_version()
 
     def get_composite_normalization_version(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "robokop-orion"
-version = "1.3.1"
+version = "1.3.2"
 description = "ORION ingests data from knowledge bases and converts it into interoperable Biolink Model knowledge graphs."
 license = "MIT"
 license-files = ["LICEN[CS]E*"]


### PR DESCRIPTION
Most modern python libraries expect the importer to configure log handlers etc and for imported packages to not start emitting logs to stderr. ORION did that before and it resulted in duplicate logs when imported by packages that added their own log handlers. This moves ORION logging handlers to the main() functions where ORION cli entry points will use them, but users of ORION as an imported library will not get ORION log handlers by default. 

Logs written to file still work either way if ORION_LOGS is set.

This also writes all ORION logs to one file instead of many, which is more typical. The module names are included in the log format now, so it's easy to grep and find ones from a particular module if desired.