### PR TITLE
Fix BindingDB affinity parsing

### DIFF
--- a/orion/kgx_file_writer.py
+++ b/orion/kgx_file_writer.py
@@ -129,7 +129,10 @@ class KGXFileWriter:
             edge_object[AGGREGATOR_KNOWLEDGE_SOURCES] = aggregator_knowledge_sources
 
         if edge_properties is not None:
-            edge_object.update({k: v for k, v in edge_properties.items() if v})
+            edge_object.update({
+                k: v for k, v in edge_properties.items()
+                if v is not None and v != '' and v != [] and v != {}
+            })
 
         self.__write_edge_to_file(edge_object)
 

--- a/orion/utils.py
+++ b/orion/utils.py
@@ -245,6 +245,51 @@ class GetData:
         # return the number of bytes read
         return byte_counter
 
+    def pull_via_http_session_gate(self,
+                                   url: str,
+                                   data_dir: str,
+                                   gate_url: str,
+                                   gate_params: dict = None,
+                                   expected_content_type: str = None,
+                                   saved_file_name: str = None,
+                                   chunk_size: int = 1024 * 1024) -> int:
+        """
+        Gets a file from an HTTP stream after first visiting a session-gating URL.
+
+        Some source sites set cookies or other session state from a JSP/download gate before allowing
+        direct file access. This method keeps that pattern in shared retrieval code instead of in parsers.
+        """
+        data_file: str = saved_file_name if saved_file_name else url.split('/')[-1]
+        output_path = os.path.join(data_dir, data_file)
+        if os.path.exists(output_path):
+            return 1
+
+        logger.debug(f'Retrieving gated HTTP file {url} -> {data_dir}')
+        try:
+            os.makedirs(data_dir, exist_ok=True)
+            byte_counter: int = 0
+            session = requests.Session()
+            session.get(gate_url, params=gate_params, timeout=30).raise_for_status()
+            with session.get(url, stream=True, timeout=60) as response:
+                response.raise_for_status()
+                if expected_content_type and response.headers.get('Content-Type') != expected_content_type:
+                    raise GetDataPullError(
+                        f'Unexpected content type retrieving {url}: {response.headers.get("Content-Type")}'
+                    )
+
+                partial_output_path = f'{output_path}.part'
+                with open(partial_output_path, 'wb') as output_file:
+                    for chunk in response.iter_content(chunk_size=chunk_size):
+                        if chunk:
+                            byte_counter += len(chunk)
+                            output_file.write(chunk)
+                os.replace(partial_output_path, output_path)
+                return byte_counter
+        except Exception as e:
+            error_message = f'GetDataPullError pull_via_http_session_gate() failed. URL: {url}. Exception: {e}'
+            logger.error(error_message)
+            raise GetDataPullError(error_message)
+
     def get_swiss_prot_id_set(self, data_dir: str, debug_mode=False) -> set:
         """
         gets/parses the swiss-prot listing file and returns a set of uniprot kb ids from

--- a/parsers/BINDING/src/loadBINDINGDB.py
+++ b/parsers/BINDING/src/loadBINDINGDB.py
@@ -8,7 +8,6 @@ from zipfile import ZipFile
 from requests.adapters import HTTPAdapter, Retry
 
 from parsers.BINDING.src.bindingdb_constraints import LOG_SCALE_AFFINITY_THRESHOLD #Change the binding affinity threshold here. Default is 10 uM Ki,Kd,EC50,orIC50
-from orion.utils import GetData
 from orion.loader_interface import SourceDataLoader
 from orion.extractor import Extractor
 from orion.biolink_constants import PUBLICATIONS, AFFINITY, AFFINITY_PARAMETER, KNOWLEDGE_LEVEL, AGENT_TYPE, \
@@ -31,6 +30,14 @@ class BD_EDGEUMAN(enum.IntEnum):
 
 def negative_log(concentration_nm): ### This function converts nanomolar concentrations into log-scale units (pKi/pKd/pIC50/pEC50). ###
     return -(math.log10(concentration_nm*(10**-9)))
+
+def parse_affinity_nm(affinity_value: str) -> float | None:
+    """Parse BindingDB nM affinity text into a numeric concentration."""
+    normalized_value = affinity_value.replace('<', '').replace(' ', '').replace(',', '')
+    affinity_nm = float(normalized_value)
+    if affinity_nm == 0:
+        return None
+    return affinity_nm
 
 def generate_zipfile_rows(zip_file_path, file_inside_zip, delimiter='\\t'):
         with ZipFile(zip_file_path, 'r') as zip_file:
@@ -112,10 +119,26 @@ class BINDINGDBLoader(SourceDataLoader):
         """
         Gets the bindingdb data.
         """
-        # download the zipped data
-        data_puller = GetData()
         source_url = f"{self.bindingdb_data_url}{self.archive_file}"
-        data_puller.pull_via_http(source_url, self.data_path)
+        output_path = os.path.join(self.data_path, self.archive_file)
+        if os.path.exists(output_path):
+            return True
+
+        os.makedirs(self.data_path, exist_ok=True)
+        download_gate_url = "https://www.bindingdb.org/rwd/bind/chemsearch/marvin/SDFdownload.jsp"
+        download_file = f"/rwd/bind/downloads/{self.archive_file}"
+        session = requests.Session()
+        session.get(download_gate_url, params={"download_file": download_file}, timeout=30).raise_for_status()
+        with session.get(source_url, stream=True, timeout=60) as response:
+            response.raise_for_status()
+            if response.headers.get("Content-Type") != "application/zip":
+                raise ValueError(f"BINDING-DB download did not return a zip file: {source_url}")
+            partial_output_path = f"{output_path}.part"
+            with open(partial_output_path, "wb") as output_file:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        output_file.write(chunk)
+            os.replace(partial_output_path, output_path)
         return True
 
     def parse_data(self) -> dict:
@@ -171,9 +194,9 @@ class BINDINGDBLoader(SourceDataLoader):
                     # our activity/inhibition threshold
                     if ">" in row[measure_index]:
                         continue
-                    sa = float(row[measure_index].replace('<', '').replace(' ', '').replace(',', ''))
-                    # I don't see how 0 would be a valid affinity value, so we'll skip it
-                    if sa == 0:
+                    # BindingDB values are nM concentrations. Recent TSVs include commas inside some numeric values.
+                    sa = parse_affinity_nm(row[measure_index])
+                    if sa is None:
                         continue
                     entry["supporting_affinities"].append(sa)
                     if publication is not None and publication not in entry[PUBLICATIONS]:
@@ -212,5 +235,5 @@ class BINDINGDBLoader(SourceDataLoader):
                                lambda item: item['predicate'],  # predicate
                                lambda item: {},  # subject props
                                lambda item: {},  # object props
-                               lambda item: {k: v for k, v in item.items() if key not in ['ligand', 'protein', 'predicate']}) #Edge props
+                               lambda item: {k: v for k, v in item.items() if k not in ['ligand', 'protein', 'predicate']}) #Edge props
         return extractor.load_metadata

--- a/parsers/BINDING/src/loadBINDINGDB.py
+++ b/parsers/BINDING/src/loadBINDINGDB.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 from requests.adapters import HTTPAdapter, Retry
 
 from parsers.BINDING.src.bindingdb_constraints import LOG_SCALE_AFFINITY_THRESHOLD #Change the binding affinity threshold here. Default is 10 uM Ki,Kd,EC50,orIC50
+from orion.utils import GetData
 from orion.loader_interface import SourceDataLoader
 from orion.extractor import Extractor
 from orion.biolink_constants import PUBLICATIONS, AFFINITY, AFFINITY_PARAMETER, KNOWLEDGE_LEVEL, AGENT_TYPE, \
@@ -120,25 +121,13 @@ class BINDINGDBLoader(SourceDataLoader):
         Gets the bindingdb data.
         """
         source_url = f"{self.bindingdb_data_url}{self.archive_file}"
-        output_path = os.path.join(self.data_path, self.archive_file)
-        if os.path.exists(output_path):
-            return True
-
-        os.makedirs(self.data_path, exist_ok=True)
         download_gate_url = "https://www.bindingdb.org/rwd/bind/chemsearch/marvin/SDFdownload.jsp"
         download_file = f"/rwd/bind/downloads/{self.archive_file}"
-        session = requests.Session()
-        session.get(download_gate_url, params={"download_file": download_file}, timeout=30).raise_for_status()
-        with session.get(source_url, stream=True, timeout=60) as response:
-            response.raise_for_status()
-            if response.headers.get("Content-Type") != "application/zip":
-                raise ValueError(f"BINDING-DB download did not return a zip file: {source_url}")
-            partial_output_path = f"{output_path}.part"
-            with open(partial_output_path, "wb") as output_file:
-                for chunk in response.iter_content(chunk_size=1024 * 1024):
-                    if chunk:
-                        output_file.write(chunk)
-            os.replace(partial_output_path, output_path)
+        GetData().pull_via_http_session_gate(source_url,
+                                             self.data_path,
+                                             download_gate_url,
+                                             gate_params={"download_file": download_file},
+                                             expected_content_type="application/zip")
         return True
 
     def parse_data(self) -> dict:

--- a/parsers/BINDING/src/loadBINDINGDB.py
+++ b/parsers/BINDING/src/loadBINDINGDB.py
@@ -56,7 +56,7 @@ class BINDINGDBLoader(SourceDataLoader):
 
     source_id: str = 'BINDING-DB'
     provenance_id: str = 'infores:bindingdb'
-    parsing_version = '1.7'
+    parsing_version = '1.8'
 
     def __init__(self, test_mode: bool = False, source_data_dir: str = None):
         """

--- a/tests/test_bindingdb.py
+++ b/tests/test_bindingdb.py
@@ -1,0 +1,150 @@
+import json
+import zipfile
+
+import pytest
+
+from orion.biolink_constants import AFFINITY, AFFINITY_PARAMETER
+from parsers.BINDING.src import loadBINDINGDB
+from parsers.BINDING.src.loadBINDINGDB import BINDINGDBLoader, negative_log, parse_affinity_nm
+
+
+def make_bindingdb_row(values):
+    row = [""] * 46
+    for index, value in values.items():
+        row[index] = value
+    return "\t".join(row)
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected_nm"),
+    [
+        (".10,000", 0.1),
+        ("10,000", 10000.0),
+        ("<10,000", 10000.0),
+        (" 1,234.5 ", 1234.5),
+    ],
+)
+def test_parse_affinity_nm_removes_bindingdb_commas(raw_value, expected_nm):
+    assert parse_affinity_nm(raw_value) == expected_nm
+
+
+def test_parse_affinity_nm_skips_zero_values():
+    assert parse_affinity_nm("0") is None
+
+
+def test_parse_affinity_nm_fails_on_invalid_values():
+    with pytest.raises(ValueError):
+        parse_affinity_nm("not-a-number")
+
+
+def test_bindingdb_get_data_uses_download_gate(tmp_path, monkeypatch):
+    monkeypatch.setattr(BINDINGDBLoader, "get_latest_source_version", lambda self: "test")
+
+    class FakeResponse:
+        def __init__(self, content=b"", content_type="application/zip"):
+            self.content = content
+            self.headers = {"Content-Type": content_type}
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield self.content
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            if "SDFdownload.jsp" in url:
+                return FakeResponse()
+            return FakeResponse(content=b"zip-content")
+
+    fake_session = FakeSession()
+    monkeypatch.setattr(loadBINDINGDB.requests, "Session", lambda: fake_session)
+
+    loader = BINDINGDBLoader(test_mode=True, source_data_dir=str(tmp_path))
+    assert loader.get_data() is True
+
+    output_path = tmp_path / "source" / loader.archive_file
+    assert output_path.read_bytes() == b"zip-content"
+    assert fake_session.calls[0][0].endswith("SDFdownload.jsp")
+    assert fake_session.calls[0][1]["params"]["download_file"] == (
+        f"/rwd/bind/downloads/{loader.archive_file}"
+    )
+    assert fake_session.calls[1][0] == (
+        f"https://www.bindingdb.org/rwd/bind/downloads/{loader.archive_file}"
+    )
+
+
+def test_bindingdb_loader_outputs_expected_affinities_for_comma_values(tmp_path, monkeypatch):
+    monkeypatch.setattr(BINDINGDBLoader, "get_latest_source_version", lambda self: "test")
+
+    loader = BINDINGDBLoader(test_mode=True, source_data_dir=str(tmp_path))
+    zip_path = tmp_path / "source" / loader.archive_file
+    header = "\t".join(f"column_{index}" for index in range(46))
+    rows = [
+        make_bindingdb_row({
+            8: ".10,000",
+            19: "12345",
+            20: "678",
+            31: "111",
+            44: "P11111",
+            45: "tail",
+        }),
+        make_bindingdb_row({
+            10: "<10,000",
+            21: "US123",
+            31: "222",
+            44: "P22222",
+            45: "tail",
+        }),
+        make_bindingdb_row({
+            8: ">10,000",
+            31: "333",
+            44: "P33333",
+            45: "tail",
+        }),
+        make_bindingdb_row({
+            8: "0",
+            31: "444",
+            44: "P44444",
+            45: "tail",
+        }),
+    ]
+    with zipfile.ZipFile(zip_path, "w") as zip_file:
+        zip_file.writestr(loader.bd_file_name, header + "\n" + "\n".join(rows) + "\n")
+
+    nodes_path = tmp_path / "nodes.jsonl"
+    edges_path = tmp_path / "edges.jsonl"
+    metadata = loader.load(str(nodes_path), str(edges_path))
+
+    edges = [json.loads(line) for line in edges_path.read_text().splitlines()]
+    assert metadata["source_edges"] == 2
+    assert len(edges) == 2
+
+    pki_edge = next(edge for edge in edges if edge["subject"] == "PUBCHEM.COMPOUND:111")
+    assert pki_edge[AFFINITY_PARAMETER] == "pKi"
+    assert pki_edge[AFFINITY] == round(negative_log(0.1), 2)
+    assert pki_edge["supporting_affinities"] == [round(negative_log(0.1), 2)]
+    assert pki_edge["publications"] == ["PMID:12345"]
+    assert pki_edge["pubchem_assay_ids"] == ["PUBCHEM.AID:678"]
+    assert "ligand" not in pki_edge
+    assert "protein" not in pki_edge
+
+    pkd_edge = next(edge for edge in edges if edge["subject"] == "PUBCHEM.COMPOUND:222")
+    assert pkd_edge[AFFINITY_PARAMETER] == "pKd"
+    assert pkd_edge[AFFINITY] == round(negative_log(10000.0), 2)
+    assert pkd_edge["supporting_affinities"] == [round(negative_log(10000.0), 2)]
+    assert pkd_edge["patent_ids"] == ["PATENT:US123"]
+
+    skipped_subjects = {edge["subject"] for edge in edges}
+    assert "PUBCHEM.COMPOUND:333" not in skipped_subjects
+    assert "PUBCHEM.COMPOUND:444" not in skipped_subjects

--- a/tests/test_bindingdb.py
+++ b/tests/test_bindingdb.py
@@ -4,7 +4,6 @@ import zipfile
 import pytest
 
 from orion.biolink_constants import AFFINITY, AFFINITY_PARAMETER
-from parsers.BINDING.src import loadBINDINGDB
 from parsers.BINDING.src.loadBINDINGDB import BINDINGDBLoader, negative_log, parse_affinity_nm
 
 
@@ -37,51 +36,30 @@ def test_parse_affinity_nm_fails_on_invalid_values():
         parse_affinity_nm("not-a-number")
 
 
-def test_bindingdb_get_data_uses_download_gate(tmp_path, monkeypatch):
+def test_bindingdb_get_data_uses_shared_session_gate(tmp_path, monkeypatch):
     monkeypatch.setattr(BINDINGDBLoader, "get_latest_source_version", lambda self: "test")
 
-    class FakeResponse:
-        def __init__(self, content=b"", content_type="application/zip"):
-            self.content = content
-            self.headers = {"Content-Type": content_type}
+    calls = []
 
-        def raise_for_status(self):
-            return None
+    def fake_pull_via_http_session_gate(self, url, data_dir, gate_url, **kwargs):
+        calls.append((url, data_dir, gate_url, kwargs))
+        return True
 
-        def iter_content(self, chunk_size):
-            yield self.content
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            return False
-
-    class FakeSession:
-        def __init__(self):
-            self.calls = []
-
-        def get(self, url, **kwargs):
-            self.calls.append((url, kwargs))
-            if "SDFdownload.jsp" in url:
-                return FakeResponse()
-            return FakeResponse(content=b"zip-content")
-
-    fake_session = FakeSession()
-    monkeypatch.setattr(loadBINDINGDB.requests, "Session", lambda: fake_session)
+    monkeypatch.setattr("parsers.BINDING.src.loadBINDINGDB.GetData.pull_via_http_session_gate",
+                        fake_pull_via_http_session_gate)
 
     loader = BINDINGDBLoader(test_mode=True, source_data_dir=str(tmp_path))
     assert loader.get_data() is True
 
-    output_path = tmp_path / "source" / loader.archive_file
-    assert output_path.read_bytes() == b"zip-content"
-    assert fake_session.calls[0][0].endswith("SDFdownload.jsp")
-    assert fake_session.calls[0][1]["params"]["download_file"] == (
+    assert len(calls) == 1
+    url, data_dir, gate_url, kwargs = calls[0]
+    assert url == f"https://www.bindingdb.org/rwd/bind/downloads/{loader.archive_file}"
+    assert data_dir == str(tmp_path / "source")
+    assert gate_url.endswith("SDFdownload.jsp")
+    assert kwargs["gate_params"]["download_file"] == (
         f"/rwd/bind/downloads/{loader.archive_file}"
     )
-    assert fake_session.calls[1][0] == (
-        f"https://www.bindingdb.org/rwd/bind/downloads/{loader.archive_file}"
-    )
+    assert kwargs["expected_content_type"] == "application/zip"
 
 
 def test_bindingdb_loader_outputs_expected_affinities_for_comma_values(tmp_path, monkeypatch):

--- a/tests/test_file_writer.py
+++ b/tests/test_file_writer.py
@@ -167,3 +167,29 @@ def test_writing_json_lines():
     assert count_lines(edges_file_path) == 500
     remove_old_files()
 
+
+def test_writing_edge_keeps_zero_and_false_properties():
+    remove_old_files()
+    with KGXFileWriter(nodes_file_path, edges_file_path) as test_file_writer:
+        edge = kgxedge(subject_id='TEST:1',
+                       object_id='TEST:2',
+                       predicate='biolink:related_to',
+                       primary_knowledge_source='infores:testing',
+                       edgeprops={'zero_float': 0.0,
+                                  'zero_int': 0,
+                                  'false_bool': False,
+                                  'none_value': None,
+                                  'empty_string': '',
+                                  'empty_list': [],
+                                  'empty_dict': {}})
+        test_file_writer.write_kgx_edge(edge)
+
+    written_edge = next(quick_jsonl_file_iterator(edges_file_path))
+    assert written_edge['zero_float'] == 0.0
+    assert written_edge['zero_int'] == 0
+    assert written_edge['false_bool'] is False
+    assert 'none_value' not in written_edge
+    assert 'empty_string' not in written_edge
+    assert 'empty_list' not in written_edge
+    assert 'empty_dict' not in written_edge
+    remove_old_files()

--- a/tests/test_utils_get_data.py
+++ b/tests/test_utils_get_data.py
@@ -1,0 +1,92 @@
+import pytest
+
+from orion import utils
+from orion.utils import GetData, GetDataPullError
+
+
+class FakeResponse:
+    def __init__(self, content=b"", content_type="application/zip"):
+        self.content = content
+        self.headers = {"Content-Type": content_type}
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size):
+        yield self.content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class FakeSession:
+    def __init__(self, download_response):
+        self.calls = []
+        self.download_response = download_response
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        if len(self.calls) == 1:
+            return FakeResponse()
+        return self.download_response
+
+
+def test_pull_via_http_session_gate_downloads_file(tmp_path, monkeypatch):
+    fake_session = FakeSession(FakeResponse(content=b"zip-content"))
+    monkeypatch.setattr(utils.requests, "Session", lambda: fake_session)
+
+    bytes_read = GetData().pull_via_http_session_gate(
+        "https://example.org/files/data.zip",
+        str(tmp_path),
+        "https://example.org/download.jsp",
+        gate_params={"download_file": "/files/data.zip"},
+        expected_content_type="application/zip",
+    )
+
+    assert bytes_read == len(b"zip-content")
+    assert (tmp_path / "data.zip").read_bytes() == b"zip-content"
+    assert not (tmp_path / "data.zip.part").exists()
+    assert fake_session.calls[0] == (
+        "https://example.org/download.jsp",
+        {"params": {"download_file": "/files/data.zip"}, "timeout": 30},
+    )
+    assert fake_session.calls[1][0] == "https://example.org/files/data.zip"
+    assert fake_session.calls[1][1]["stream"] is True
+
+
+def test_pull_via_http_session_gate_skips_existing_file(tmp_path, monkeypatch):
+    output_path = tmp_path / "renamed.zip"
+    output_path.write_bytes(b"existing")
+
+    def fail_if_called():
+        raise AssertionError("Session should not be created when the output file exists")
+
+    monkeypatch.setattr(utils.requests, "Session", fail_if_called)
+
+    bytes_read = GetData().pull_via_http_session_gate(
+        "https://example.org/files/data.zip",
+        str(tmp_path),
+        "https://example.org/download.jsp",
+        saved_file_name="renamed.zip",
+    )
+
+    assert bytes_read == 1
+    assert output_path.read_bytes() == b"existing"
+
+
+def test_pull_via_http_session_gate_fails_on_unexpected_content_type(tmp_path, monkeypatch):
+    fake_session = FakeSession(FakeResponse(content=b"<html></html>", content_type="text/html"))
+    monkeypatch.setattr(utils.requests, "Session", lambda: fake_session)
+
+    with pytest.raises(GetDataPullError):
+        GetData().pull_via_http_session_gate(
+            "https://example.org/files/data.zip",
+            str(tmp_path),
+            "https://example.org/download.jsp",
+            expected_content_type="application/zip",
+        )
+
+    assert not (tmp_path / "data.zip").exists()


### PR DESCRIPTION
## Summary
- Parse comma-containing BindingDB affinity values through an explicit helper before converting nM values to p-affinity values.
- Add a shared GetData.pull_via_http_session_gate helper for JSP/session-gated HTTP downloads, and use it from BindingDB with source-specific gate parameters.
- Fix BINDING edge property filtering so emitted edges do not carry redundant ligand/protein fields.
- Preserve meaningful falsey KGX edge properties such as 0.0, 0, and false while still dropping empty values.

Closes #340.
Refs #339 for the current BindingDB download-gate behavior; #339 remains broader because it also covers upstream instability and backup-hosting strategy.

## Validation
- Ran the full BindingDB parser against BindingDB_All_202605_tsv.zip after the shared-helper refactor.
- Full parser output: 1,245,507 nodes and 1,969,874 edges, with 0 parser errors and 0 skipped records.
- Post-run edge checks found no invalid affinity/supporting affinity values, no missing top-level affinity values, and no redundant ligand/protein edge properties.
- Current 202605 full TSV scan found 0 comma-containing values in Ki, IC50, Kd, or EC50 columns, so the reported comma issue appears historical or source-version-specific but is now covered.

## Tests
- uv run pytest tests/test_bindingdb.py tests/test_utils_get_data.py tests/test_file_writer.py tests/test_loaders.py
- git diff --check