### PR TITLE
Rewrite DrugMechDB parser

### DIFF
--- a/parsers/drugmechdb/src/loadDrugMechDB.py
+++ b/parsers/drugmechdb/src/loadDrugMechDB.py
@@ -1,32 +1,82 @@
 import json
-import requests as rq
 import os
-import pandas as pd
-import ast
+
+import requests
+from requests.adapters import HTTPAdapter, Retry
 
 from orion.utils import GetData
 from orion.loader_interface import SourceDataLoader
 from orion.kgxmodel import kgxnode, kgxedge
-from orion.extractor import Extractor
 from orion.biolink_constants import KNOWLEDGE_LEVEL, KNOWLEDGE_ASSERTION, AGENT_TYPE, MANUAL_AGENT, \
     QUALIFIED_PREDICATE, OBJECT_ASPECT_QUALIFIER, OBJECT_DIRECTION_QUALIFIER
 
-def load_json(json_data):
-    with open(json_data, encoding="utf-8-sig") as file:
-        data = json.load(file)
-    file.close()
-    return data
 
-##############
-# Class: Load in full Clinical Outcome Pathways and direct Gene/Protein-[biolink:target_for]->Disease relationships from DrugMechDB.
-# By: Jon-Michael Beasley
-# Date: 09/06/2023
-##############
+def iter_json_array(json_file_path: str, chunk_size: int = 1024 * 1024):
+    decoder = json.JSONDecoder()
+    buffer = ""
+    started = False
+    first_item = True
+    eof = False
+
+    with open(json_file_path, encoding="utf-8-sig") as json_file:
+        while True:
+            if not buffer and not eof:
+                chunk = json_file.read(chunk_size)
+                if chunk:
+                    buffer += chunk
+                else:
+                    eof = True
+
+            buffer = buffer.lstrip()
+            if not started:
+                if not buffer and eof:
+                    raise ValueError(f"Expected JSON array in {json_file_path}")
+                if not buffer:
+                    continue
+                if buffer[0] != "[":
+                    raise ValueError(f"Expected JSON array in {json_file_path}")
+                buffer = buffer[1:]
+                started = True
+                continue
+
+            buffer = buffer.lstrip()
+            if buffer.startswith("]"):
+                return
+
+            if not first_item:
+                if not buffer and eof:
+                    raise ValueError(f"Unexpected end of JSON array in {json_file_path}")
+                if not buffer:
+                    continue
+                if buffer[0] != ",":
+                    raise ValueError(f"Expected ',' between JSON array items in {json_file_path}")
+                buffer = buffer[1:].lstrip()
+                if buffer.startswith("]"):
+                    return
+
+            while True:
+                try:
+                    item, index = decoder.raw_decode(buffer)
+                    break
+                except json.JSONDecodeError:
+                    if eof:
+                        raise
+                    chunk = json_file.read(chunk_size)
+                    if chunk:
+                        buffer += chunk
+                    else:
+                        eof = True
+
+            yield item
+            buffer = buffer[index:]
+            first_item = False
+
+
 class DrugMechDBLoader(SourceDataLoader):
 
     source_id: str = 'DrugMechDB'
     provenance_id: str = 'infores:drugmechdb'
-    parsing_version = '1.3'
+    parsing_version = '1.4'
 
     def __init__(self, test_mode: bool = False, source_data_dir: str = None):
         """
@@ -45,191 +95,207 @@ class DrugMechDBLoader(SourceDataLoader):
         self.predicate_mapping_file = os.path.join(self.mapping_filepath, self.predicate_mapping)
         self.node_mapping_file = os.path.join(self.mapping_filepath, self.node_mapping)
 
-    #TODO Write the function below to get latest update version from https://sulab.github.io/DrugMechDB/
     def get_latest_source_version(self) -> str:
         """
         gets the latest version of the data
         :return:
         """
-        ### The method below gets the database version from the html, but this may be subject to change. ###
-        drugmechdb_download_page_response = rq.get('https://github.com/SuLab/DrugMechDB')
-        version_index = drugmechdb_download_page_response.text.index('/SuLab/DrugMechDB/releases/tag/') + 31
-        drugmechdb_version = drugmechdb_download_page_response.text[version_index:version_index + 5]
-        return f"{drugmechdb_version}"
-    
+        session = requests.Session()
+        retries = Retry(total=5, backoff_factor=2)
+        session.mount('https://', HTTPAdapter(max_retries=retries))
+        response = session.get('https://github.com/SuLab/DrugMechDB', timeout=30)
+        response.raise_for_status()
+        version_index = response.text.index('/SuLab/DrugMechDB/releases/tag/') + 31
+        return response.text[version_index:version_index + 5]
+
     def get_data(self) -> int:
         """
         Gets the DrugMechDB data.
         """
         data_puller = GetData()
-        i=0
         for source in self.data_files:
             source_url = f"{self.drugmechdb_data_url}{source}"
             data_puller.pull_via_http(source_url, self.data_path)
-            i+=1
         return True
-    
-    def fix_node(self,node_id,mapping_dictionary):
-        fixed_node = node_id.replace('UniProt:', 'UniProtKB:').replace('InterPro:','interpro:').replace('reactome:','REACT:').replace('taxonomy:','NCBITaxon:').replace('Pfam:','PFAM:').replace('DB:','DRUGBANK:').replace('\ufeff','')
+
+    def fix_node(self, node_id, mapping_dictionary):
+        fixed_node = node_id.replace('UniProt:', 'UniProtKB:')\
+                            .replace('InterPro:', 'interpro:')\
+                            .replace('reactome:', 'REACT:')\
+                            .replace('taxonomy:', 'NCBITaxon:')\
+                            .replace('Pfam:', 'PFAM:')\
+                            .replace('DB:', 'DRUGBANK:')\
+                            .replace('\ufeff', '')
         if fixed_node in mapping_dictionary.keys():
             fixed_node = mapping_dictionary[fixed_node]["id"]
         return fixed_node
-    
+
     def parse_data(self) -> dict:
         """
         Parses the data file for graph nodes/edges
 
-        :return: ret_val: load_metadata
+        :return: load_metadata
         """
-        ### This dict stores the edges created for each entry, then it will be grouped and agggregated to merge drugmechdb path ids.
-        source_target_pair_dict = {
-            "dmdb_ids":[],
-            "source_ids":[],
-            "target_ids":[],
-            "predicates":[],
-            "qualified_predicates":[],
-            "object_direction_qualifiers":[],
-            "object_aspect_qualifiers":[]
-        }
-        ### This dict stores the edges created for the new "biolink:target_for" edges, then it will be grouped and agggregated to merge drugmechdb path ids.
-        triple_pair_dict = {
-            "dmdb_ids":[],
-            "drug_names":[],
-            "drug_meshs":[],
-            "drug_drugbanks":[],
-            "drug_target_names":[],
-            "drug_target_uniprots":[],
-            "disease_names":[],
-            "disease_meshs":[]
-        }
+        with open(self.predicate_mapping_file) as predicate_mapping_file:
+            predicate_mapping = json.load(predicate_mapping_file)
+        with open(self.node_mapping_file) as node_mapping_file:
+            node_mapping = json.load(node_mapping_file)
 
-        data = load_json(os.path.join(self.data_path,self.drugmechdb_file_name))
+        mechanism_edges = {}
+        target_for_edges = {}
+        record_counter = 0
+        data_file_path = os.path.join(self.data_path, self.drugmechdb_file_name)
 
-         # init the record counters
-        record_counter: int = 0
-        skipped_record_counter: int = 0
-        with open(self.predicate_mapping_file, "r") as pm:
-            predicate_mapping = json.load(pm)
-        with open(self.node_mapping_file, "r") as nm:
-            node_mapping = json.load(nm)
-        for entry in data:
-            dmdb_id = entry["graph"]["_id"]
-            drug_name = entry["graph"]["drug"]
-            drug_mesh = entry["graph"]["drug_mesh"]
-            drug_drugbank = entry["graph"]["drugbank"]
-            disease_name = entry["graph"]["disease"]
-            disease_mesh = entry["graph"]["disease_mesh"]
-            links  = entry["links"] 
-            for i in range(len(links)):
-                triple = links[i]
+        for entry in iter_json_array(data_file_path):
+            record_counter += 1
+            self.parse_entry(entry, predicate_mapping, node_mapping, mechanism_edges, target_for_edges)
 
-                source_target_pair_dict["dmdb_ids"].append(dmdb_id)
+        for edge_key in sorted(mechanism_edges):
+            source_id, target_id, predicate, qualified_predicate, direction_qualifier, aspect_qualifier = edge_key
+            edge_props = {
+                "drugmechdb_path_id": sorted(mechanism_edges[edge_key]),
+                KNOWLEDGE_LEVEL: KNOWLEDGE_ASSERTION,
+                AGENT_TYPE: MANUAL_AGENT
+            }
+            if qualified_predicate:
+                edge_props[QUALIFIED_PREDICATE] = qualified_predicate
+            if direction_qualifier:
+                edge_props[OBJECT_DIRECTION_QUALIFIER] = direction_qualifier
+            if aspect_qualifier:
+                edge_props[OBJECT_ASPECT_QUALIFIER] = aspect_qualifier
 
-                source = triple["source"]
-                fixed_source = self.fix_node(source,node_mapping)
-                source_target_pair_dict["source_ids"].append(fixed_source)
-                output_node = kgxnode(fixed_source)
-                self.output_file_writer.write_kgx_node(output_node)
-
-                target = triple["target"]
-                fixed_target = self.fix_node(target,node_mapping)
-                source_target_pair_dict["target_ids"].append(fixed_target)
-                output_node = kgxnode(fixed_target)
-                self.output_file_writer.write_kgx_node(output_node)
-                
-                predicate = "biolink:" + triple["key"].replace(" ","_")
-                if predicate in predicate_mapping.keys():
-                    source_target_pair_dict["qualified_predicates"].append(predicate_mapping[predicate]["properties"]["qualified_predicate"])
-                    source_target_pair_dict["object_direction_qualifiers"].append(predicate_mapping[predicate]["properties"]["object_direction_qualifier"])
-                    source_target_pair_dict["object_aspect_qualifiers"].append(predicate_mapping[predicate]["properties"]["object_aspect_qualifier"])
-                    predicate = predicate_mapping[predicate]["predicate"]
-                else:
-                    source_target_pair_dict["qualified_predicates"].append("")
-                    source_target_pair_dict["object_direction_qualifiers"].append("")
-                    source_target_pair_dict["object_aspect_qualifiers"].append("")
-
-                source_target_pair_dict["predicates"].append(predicate)
-
-                ### The next section finds the drug target for assigning "biolink:target_for" edges.
-                nodes = entry["nodes"]
-                if source == drug_mesh:
-                    for node in nodes:
-                        if (node["id"] == target) and (node["label"] in ["Protein","GeneFamily"]):
-
-                            drug_target_name = node["name"]
-                            drug_target_uniprot = self.fix_node(node["id"],node_mapping)
-                            disease_mesh = self.fix_node(disease_mesh,node_mapping)
-                            triple_pair_dict["dmdb_ids"].append(dmdb_id)
-                            triple_pair_dict["drug_names"].append(drug_name)
-                            triple_pair_dict["drug_meshs"].append(drug_mesh)
-                            triple_pair_dict["drug_drugbanks"].append(drug_drugbank)
-                            triple_pair_dict["drug_target_names"].append(drug_target_name)
-                            triple_pair_dict["drug_target_uniprots"].append(drug_target_uniprot)
-                            triple_pair_dict["disease_names"].append(disease_name)
-                            triple_pair_dict["disease_meshs"].append(disease_mesh)
-                        
-                        ### If the next node after the drug is a metabolite of the drug, then go forward one link and check if the next node is the target.
-                        elif node["id"] == target and node["label"] in ["Drug","ChemicalSubstance"]:
-                            if entry["links"][i+1]["source"] == node["id"]:
-                                new_target = entry["links"][i+1]["target"]
-                                for node in nodes:
-                                    if (node["id"] == new_target) and (node["label"] in ["Protein","GeneFamily"]):
-                                        drug_target_name = node["name"]
-                                        drug_target_uniprot = self.fix_node(node["id"],node_mapping)
-                                        disease_mesh = self.fix_node(disease_mesh,node_mapping)
-                                        triple_pair_dict["dmdb_ids"].append(dmdb_id)
-                                        triple_pair_dict["drug_names"].append(drug_name)
-                                        triple_pair_dict["drug_meshs"].append(drug_mesh)
-                                        triple_pair_dict["drug_drugbanks"].append(drug_drugbank)
-                                        triple_pair_dict["drug_target_names"].append(drug_target_name)
-                                        triple_pair_dict["drug_target_uniprots"].append(drug_target_uniprot)
-                                        triple_pair_dict["disease_names"].append(disease_name)
-                                        triple_pair_dict["disease_meshs"].append(disease_mesh)
-                        else:
-                            continue
-
-        df = pd.DataFrame(source_target_pair_dict)
-        df = df.groupby(["source_ids","target_ids","predicates","qualified_predicates","object_direction_qualifiers","object_aspect_qualifiers"], as_index=False).agg(list).reset_index(drop=True)
-        df['dmdb_ids'] = df['dmdb_ids'].apply(lambda x: list(set(x))) ###Removes duplicates
-        for index, row in df.iterrows():
-            edge_props = {"drugmechdb_path_id": row["dmdb_ids"],
-                          KNOWLEDGE_LEVEL: KNOWLEDGE_ASSERTION,
-                          AGENT_TYPE: MANUAL_AGENT}
-            if row["qualified_predicates"] != "":
-                edge_props[QUALIFIED_PREDICATE] = row["qualified_predicates"]
-            if row["object_direction_qualifiers"] != "":
-                edge_props[OBJECT_DIRECTION_QUALIFIER] = row["object_direction_qualifiers"]
-            if row["object_aspect_qualifiers"] != "":
-                edge_props[OBJECT_ASPECT_QUALIFIER] = row["object_aspect_qualifiers"]
-            output_edge = kgxedge(
-                        subject_id=row["source_ids"],
-                        object_id=row["target_ids"],
-                        predicate=row["predicates"],
-                        edgeprops=edge_props,
-                        primary_knowledge_source=self.provenance_id
-                    )
+            output_edge = kgxedge(subject_id=source_id,
+                                  object_id=target_id,
+                                  predicate=predicate,
+                                  edgeprops=edge_props,
+                                  primary_knowledge_source=self.provenance_id)
             self.output_file_writer.write_kgx_edge(output_edge)
-        
-        ### Saves the "biolink:target_for" edges as a CSV file, which is useful as a benchmarking dataset.
-        df = pd.DataFrame(triple_pair_dict)
-        df= df.groupby(["drug_names","drug_meshs","drug_drugbanks","drug_target_names","drug_target_uniprots","disease_names","disease_meshs"], as_index=False).agg(list).reset_index(drop=True)
-        df['dmdb_ids'] = df['dmdb_ids'].apply(lambda x: list(set(x))) ###Removes duplicates
-        csv_file_name = os.path.join(self.data_path,"indication_paths.csv")
-        df.to_csv(csv_file_name)
-        
-        extractor = Extractor(file_writer=self.output_file_writer)
-        with open(csv_file_name, 'rt') as fp:
-            extractor.csv_extract(fp,
-                    lambda line: line[5],  # subject id
-                    lambda line: line[7],  # object id
-                    lambda line: "biolink:target_for",
-                    lambda line: {}, #Node 1 props
-                    lambda line: {}, #Node 2 props
-                    lambda line: {"drugmechdb_path_id": ast.literal_eval(line[8]),
-                                  KNOWLEDGE_LEVEL: KNOWLEDGE_ASSERTION,
-                                  AGENT_TYPE: MANUAL_AGENT}, #Edge props
-                    comment_character=None,
-                    delim=",",
-                    has_header_row=True
-                )
-        return extractor.load_metadata
+
+        for edge_key in sorted(target_for_edges):
+            drug_target_id, disease_id, _drug_name, _drug_mesh, _drugbank, _drug_target_name, _disease_name = edge_key
+            self.output_file_writer.write_kgx_node(kgxnode(drug_target_id))
+            self.output_file_writer.write_kgx_node(kgxnode(disease_id))
+            edge_props = {
+                "drugmechdb_path_id": sorted(target_for_edges[edge_key]),
+                KNOWLEDGE_LEVEL: KNOWLEDGE_ASSERTION,
+                AGENT_TYPE: MANUAL_AGENT
+            }
+            output_edge = kgxedge(subject_id=drug_target_id,
+                                  object_id=disease_id,
+                                  predicate="biolink:target_for",
+                                  edgeprops=edge_props,
+                                  primary_knowledge_source=self.provenance_id)
+            self.output_file_writer.write_kgx_edge(output_edge)
+
+        return {'record_counter': record_counter,
+                'skipped_record_counter': 0,
+                'errors': []}
+
+    def parse_entry(self, entry, predicate_mapping, node_mapping, mechanism_edges, target_for_edges):
+        graph = entry["graph"]
+        dmdb_id = graph["_id"]
+        drug_name = graph["drug"]
+        drug_mesh = graph["drug_mesh"]
+        drug_drugbank = graph["drugbank"]
+        disease_name = graph["disease"]
+        disease_id = self.fix_node(graph["disease_mesh"], node_mapping)
+        nodes_by_id = self.get_nodes_by_id(entry["nodes"])
+
+        links = entry["links"]
+        for index, triple in enumerate(links):
+            source_id = self.fix_node(triple["source"], node_mapping)
+            target_id = self.fix_node(triple["target"], node_mapping)
+            self.output_file_writer.write_kgx_node(kgxnode(source_id))
+            self.output_file_writer.write_kgx_node(kgxnode(target_id))
+
+            predicate, qualified_predicate, direction_qualifier, aspect_qualifier = \
+                self.map_predicate(triple["key"], predicate_mapping)
+            edge_key = (source_id, target_id, predicate, qualified_predicate, direction_qualifier, aspect_qualifier)
+            mechanism_edges.setdefault(edge_key, set()).add(dmdb_id)
+
+            if triple["source"] == drug_mesh:
+                self.add_target_for_edge(index,
+                                         links,
+                                         nodes_by_id,
+                                         triple["target"],
+                                         dmdb_id,
+                                         drug_name,
+                                         drug_mesh,
+                                         drug_drugbank,
+                                         disease_name,
+                                         disease_id,
+                                         node_mapping,
+                                         target_for_edges)
+
+    def map_predicate(self, key, predicate_mapping):
+        predicate = "biolink:" + key.replace(" ", "_")
+        mapped_predicate = predicate_mapping.get(predicate)
+        if not mapped_predicate:
+            return predicate, "", "", ""
+        properties = mapped_predicate["properties"]
+        return (mapped_predicate["predicate"],
+                properties["qualified_predicate"],
+                properties["object_direction_qualifier"],
+                properties["object_aspect_qualifier"])
+
+    def add_target_for_edge(self,
+                            link_index,
+                            links,
+                            nodes_by_id,
+                            target_id,
+                            dmdb_id,
+                            drug_name,
+                            drug_mesh,
+                            drug_drugbank,
+                            disease_name,
+                            disease_id,
+                            node_mapping,
+                            target_for_edges):
+        for node in nodes_by_id.get(target_id, []):
+            if node["label"] in ["Protein", "GeneFamily"]:
+                self.add_drug_target(dmdb_id,
+                                     drug_name,
+                                     drug_mesh,
+                                     drug_drugbank,
+                                     node["name"],
+                                     node["id"],
+                                     disease_name,
+                                     disease_id,
+                                     node_mapping,
+                                     target_for_edges)
+            elif node["label"] in ["Drug", "ChemicalSubstance"]:
+                next_link = links[link_index + 1]
+                if next_link["source"] == node["id"]:
+                    for next_node in nodes_by_id.get(next_link["target"], []):
+                        if next_node["label"] in ["Protein", "GeneFamily"]:
+                            self.add_drug_target(dmdb_id,
+                                                 drug_name,
+                                                 drug_mesh,
+                                                 drug_drugbank,
+                                                 next_node["name"],
+                                                 next_node["id"],
+                                                 disease_name,
+                                                 disease_id,
+                                                 node_mapping,
+                                                 target_for_edges)
+
+    def add_drug_target(self,
+                        dmdb_id,
+                        drug_name,
+                        drug_mesh,
+                        drug_drugbank,
+                        drug_target_name,
+                        drug_target_id,
+                        disease_name,
+                        disease_id,
+                        node_mapping,
+                        target_for_edges):
+        drug_target_id = self.fix_node(drug_target_id, node_mapping)
+        edge_key = (drug_target_id, disease_id, drug_name, drug_mesh, drug_drugbank, drug_target_name, disease_name)
+        target_for_edges.setdefault(edge_key, set()).add(dmdb_id)
+
+    def get_nodes_by_id(self, nodes):
+        nodes_by_id = {}
+        for node in nodes:
+            nodes_by_id.setdefault(node["id"], []).append(node)
+        return nodes_by_id

--- a/tests/test_drugmechdb.py
+++ b/tests/test_drugmechdb.py
@@ -1,0 +1,132 @@
+import json
+
+from parsers.drugmechdb.src.loadDrugMechDB import DrugMechDBLoader, iter_json_array
+from orion.biolink_constants import QUALIFIED_PREDICATE, OBJECT_DIRECTION_QUALIFIER, OBJECT_ASPECT_QUALIFIER
+
+
+def write_drugmechdb_source(tmp_path, entries):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "indication_paths.json").write_text(json.dumps(entries))
+
+
+def make_direct_target_entry(dmdb_id):
+    return {
+        "directed": True,
+        "graph": {
+            "_id": dmdb_id,
+            "disease": "CML (ph+)",
+            "disease_mesh": "MESH:D015464",
+            "drug": "imatinib",
+            "drug_mesh": "MESH:D000068877",
+            "drugbank": "DB:DB00619",
+        },
+        "links": [
+            {"key": "decreases activity of", "source": "MESH:D000068877", "target": "UniProt:P00519"},
+            {"key": "causes", "source": "UniProt:P00519", "target": "MESH:D015464"},
+        ],
+        "multigraph": True,
+        "nodes": [
+            {"id": "MESH:D000068877", "label": "Drug", "name": "imatinib"},
+            {"id": "UniProt:P00519", "label": "Protein", "name": "BCR/ABL"},
+            {"id": "MESH:D015464", "label": "Disease", "name": "CML (ph+)"},
+        ],
+    }
+
+
+def make_metabolite_target_entry():
+    return {
+        "directed": True,
+        "graph": {
+            "_id": "DB00000_MESH_D012345_1",
+            "disease": "test disease",
+            "disease_mesh": "MESH:D012345",
+            "drug": "test drug",
+            "drug_mesh": "MESH:D000000",
+            "drugbank": "DB:DB00000",
+        },
+        "links": [
+            {"key": "has metabolite", "source": "MESH:D000000", "target": "DB:DBMET02573"},
+            {"key": "decreases activity of", "source": "DB:DBMET02573", "target": "UniProt:P3535"},
+            {"key": "causes", "source": "UniProt:P3535", "target": "MESH:D012345"},
+        ],
+        "multigraph": True,
+        "nodes": [
+            {"id": "MESH:D000000", "label": "Drug", "name": "test drug"},
+            {"id": "DB:DBMET02573", "label": "ChemicalSubstance", "name": "metabolite"},
+            {"id": "UniProt:P3535", "label": "Protein", "name": "COX2"},
+            {"id": "MESH:D012345", "label": "Disease", "name": "test disease"},
+        ],
+    }
+
+
+def read_jsonl(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_iter_json_array_streams_array_items(tmp_path):
+    source_file = tmp_path / "data.json"
+    source_file.write_text(json.dumps([{"id": 1}, {"id": 2}, {"id": 3}]))
+
+    assert list(iter_json_array(str(source_file), chunk_size=5)) == [{"id": 1}, {"id": 2}, {"id": 3}]
+
+
+def test_drugmechdb_loader_outputs_merged_mechanism_and_target_edges(tmp_path, monkeypatch):
+    monkeypatch.setattr(DrugMechDBLoader, "get_latest_source_version", lambda self: "test")
+    entries = [
+        make_direct_target_entry("DB00619_MESH_D015464_1"),
+        make_direct_target_entry("DB00619_MESH_D015464_2"),
+        make_metabolite_target_entry(),
+    ]
+    write_drugmechdb_source(tmp_path, entries)
+
+    loader = DrugMechDBLoader(test_mode=True, source_data_dir=str(tmp_path))
+    nodes_path = tmp_path / "nodes.jsonl"
+    edges_path = tmp_path / "edges.jsonl"
+    metadata = loader.load(str(nodes_path), str(edges_path))
+
+    edges = read_jsonl(edges_path)
+    assert metadata["record_counter"] == 3
+    assert metadata["source_edges"] == 7
+    assert not (tmp_path / "source" / "indication_paths.csv").exists()
+
+    direct_mechanism = next(
+        edge for edge in edges
+        if edge["subject"] == "MESH:D000068877"
+        and edge["object"] == "UniProtKB:P00519"
+    )
+    assert direct_mechanism["predicate"] == "biolink:affects"
+    assert direct_mechanism["drugmechdb_path_id"] == [
+        "DB00619_MESH_D015464_1",
+        "DB00619_MESH_D015464_2",
+    ]
+    assert direct_mechanism[QUALIFIED_PREDICATE] == "biolink:causes"
+    assert direct_mechanism[OBJECT_DIRECTION_QUALIFIER] == "decreased"
+    assert direct_mechanism[OBJECT_ASPECT_QUALIFIER] == "activity"
+
+    direct_target_for = next(
+        edge for edge in edges
+        if edge["predicate"] == "biolink:target_for"
+        and edge["subject"] == "UniProtKB:P00519"
+    )
+    assert direct_target_for["object"] == "MESH:D015464"
+    assert direct_target_for["primary_knowledge_source"] == "infores:drugmechdb"
+    assert direct_target_for["drugmechdb_path_id"] == [
+        "DB00619_MESH_D015464_1",
+        "DB00619_MESH_D015464_2",
+    ]
+
+    metabolite_edge = next(
+        edge for edge in edges
+        if edge["subject"] == "MESH:D000000"
+        and edge["object"] == "PUBCHEM.COMPOUND:631051"
+    )
+    assert metabolite_edge["predicate"] == "biolink:has_metabolite"
+
+    metabolite_target_for = next(
+        edge for edge in edges
+        if edge["predicate"] == "biolink:target_for"
+        and edge["subject"] == "UniProtKB:P35354"
+    )
+    assert metabolite_target_for["object"] == "MESH:D012345"
+    assert metabolite_target_for["drugmechdb_path_id"] == ["DB00000_MESH_D012345_1"]


### PR DESCRIPTION
## Summary
- Rewrite the DrugMechDB parser to remove pandas, iterrows, and the intermediate indication_paths.csv side effect.
- Stream records from the indication_paths.json array and aggregate KGX edges directly with dictionaries and sets.
- Preserve DrugMechDB mechanism edges and target_for edge generation, including direct drug-target paths and drug-metabolite-target paths.
- Add focused DrugMechDB tests for streaming, node remapping, predicate qualifier mapping, path ID aggregation, target_for generation, and no CSV side effect.

Closes #223.

## Old vs new graph comparison
- Ran the old pandas-based parser against DrugMechDB 2.0.1 and saved its node/edge JSONL outputs under /tmp/drugmechdb_current.
- Ran the rewritten parser against the same downloaded indication_paths.json and saved outputs under /tmp/drugmechdb_rewrite.
- Compared line counts, predicate distributions, qualified-edge counts, target_for counts, path ID presence, and canonicalized node/edge sets.
- Canonicalization sorted each edge JSON and sorted drugmechdb_path_id lists so path ID ordering did not create false differences.

## Fidelity achieved
- Node count matched exactly: 5,075 old vs 5,075 new.
- Edge count matched exactly: 16,083 old vs 16,083 new.
- Predicate distribution matched exactly, including 5,351 biolink:target_for edges and 2,375 qualified edges.
- Canonical node set matched exactly.
- Canonical edge set matched exactly after ignoring one intentional improvement: rewritten target_for edges now include primary_knowledge_source=infores:drugmechdb, which the old CSV/Extractor path omitted.
- The new parser produced no indication_paths.csv side effect.

## Tests
- uv run pytest tests/test_drugmechdb.py tests/test_loaders.py
- Import check confirmed pandas is not loaded by parsers.drugmechdb.src.loadDrugMechDB.
- git diff --check