### PR TITLE
Preserve CTD taxon metadata

### DIFF
--- a/graph_specs/cfde-graph-spec.yaml
+++ b/graph_specs/cfde-graph-spec.yaml
@@ -5,6 +5,8 @@ graphs:
     graph_description: 'Common Fund Data Ecosystem KG'
     graph_url: https://github.com/NCATSTranslator/Translator-All/wiki/CFDE-KP
     output_format: neo4j
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: BINDING-DB
       - source_id: CHEBIProps
@@ -35,4 +37,3 @@ graphs:
       - source_id: UbergraphNonredundant
       - source_id: GWASCatalog
       - source_id: GTEx
-

--- a/graph_specs/default-graph-spec.yml
+++ b/graph_specs/default-graph-spec.yml
@@ -13,6 +13,8 @@ graphs:
     graph_url: http://robokopkg.renci.org/browser/
     conflation: True
     output_format: neo4j
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: BINDING-DB
         # optional parameters for each data source - see README for more info
@@ -57,6 +59,8 @@ graphs:
     graph_url: http://robokopkg.renci.org/browser/
     conflation: True
     output_format: neo4j
+    edge_merging_attributes:
+      - taxon
     subgraphs:
       - graph_id: Baseline
     sources:
@@ -97,6 +101,8 @@ graphs:
     graph_description: 'The Comparative Toxicogenomics Database (CTD) is an open-source database that provides manually curated information about chemical-gene/protein, chemical-disease, and gene/protein-disease relationships, with additional support for the curated relationships provided by function and pathway data.'
     graph_url: http://ctdbase.org/about/
     output_format: neo4j
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: CTD
       - source_id: OntologicalHierarchy
@@ -298,4 +304,3 @@ graphs:
       - source_id: ViralProteome
       - source_id: OntologicalHierarchy
         merge_strategy: connected_edge_subset
-

--- a/graph_specs/dug-graph-spec.yaml
+++ b/graph_specs/dug-graph-spec.yaml
@@ -5,6 +5,8 @@ graphs:
     graph_url:
     conflation: True
     output_format:
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: CHEBIProps
       - source_id: CTD

--- a/graph_specs/matrix-graph-spec.yaml
+++ b/graph_specs/matrix-graph-spec.yaml
@@ -7,6 +7,8 @@ graphs:
     graph_url: http://robokopkg.renci.org/browser/
     conflation: True
     output_format: neo4j
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: BINDING-DB
       - source_id: CCIDB

--- a/graph_specs/rule-mining-graph-spec.yaml
+++ b/graph_specs/rule-mining-graph-spec.yaml
@@ -7,6 +7,8 @@ graphs:
     graph_url:
     conflation: True
     output_format: redundant_jsonl
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: BINDING-DB
       - source_id: CHEBIProps

--- a/graph_specs/yeast-graph-spec.yml
+++ b/graph_specs/yeast-graph-spec.yml
@@ -13,6 +13,8 @@ graphs:
     graph_url: http://robokopkg.renci.org/browser/
     conflation: True
     output_format: neo4j
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: BINDING-DB
         # optional parameters for each data source - see README for more info
@@ -47,6 +49,8 @@ graphs:
   - graph_id: YobokopKG
     conflation: True
     output_format: neo4j
+    edge_merging_attributes:
+      - taxon
     subgraphs:
       - graph_id: Baseline
     sources:

--- a/orion/normalization.py
+++ b/orion/normalization.py
@@ -47,7 +47,7 @@ class NormalizationScheme:
     strict: bool = True
     conflation: bool = False
     include_description: bool = True
-    include_taxa: bool = False
+    include_taxa: bool = True
 
     def __post_init__(self):
         if self.node_normalization_version in (None, 'latest'):
@@ -101,7 +101,7 @@ class NodeNormalizer:
                  strict_normalization: bool = True,
                  conflate_node_types: bool = False,
                  include_description: bool = False,
-                 include_taxa: bool = False):
+                 include_taxa: bool = True):
         """
         constructor
         :param node_normalization_version - not implemented yet
@@ -280,7 +280,7 @@ class NodeNormalizer:
                 if current_node_normalization.get('descriptions'):
                     current_node[DESCRIPTION] = current_node_normalization['descriptions'][0]
                 if current_node_normalization.get('taxa'):
-                    current_node[TAXON] = current_node_id_section['taxa'][0]
+                    current_node[TAXON] = current_node_normalization['taxa'][0]
 
                 self.node_normalization_lookup[current_node_id] = [normalized_id]
             else:

--- a/parsers/CTD/src/loadCTD.py
+++ b/parsers/CTD/src/loadCTD.py
@@ -230,7 +230,7 @@ class CTDLoader(SourceDataLoader):
                 self.output_file_writer.write_kgx_node(chem_node)
 
                 # save the gene node
-                gene_node = kgxnode(gene_id, name=r['gene_label'], nodeprops={NCBITAXON: r['taxonID'].split(':')[1]})
+                gene_node = kgxnode(gene_id, name=r['gene_label'])
                 self.output_file_writer.write_kgx_node(gene_node)
 
                 # get the right source/object depending on the predicate direction
@@ -517,7 +517,7 @@ class CTDLoader(SourceDataLoader):
         # check for invalid data
         if good_row:
             # get the standard properties
-            props: dict = {DESCRIPTION: r['interaction'], TAXON: r['taxonID'].split(':')[1]}
+            props: dict = {DESCRIPTION: r['interaction'], TAXON: f"{NCBITAXON}:{r['taxonID'].split(':')[1]}"}
 
             # get the pubmed ids into a list
             pmids: list = r['PMID'].split('|')

--- a/tests/graph_specs/testing-graph-spec.yaml
+++ b/tests/graph_specs/testing-graph-spec.yaml
@@ -5,6 +5,8 @@ graphs:
     graph_description: 'This is a small graph spec that can be used for testing.'
     graph_url: ''
     output_format:
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: CTD
       - source_id: HGNC
@@ -14,6 +16,8 @@ graphs:
     graph_description: 'This is a graph spec that can be used for testing with a subgraph.'
     graph_url: ''
     output_format:
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: GtoPdb
     subgraphs:
@@ -34,6 +38,8 @@ graphs:
     graph_description: 'This is a graph spec that can be used for testing an invalid subgraph version.'
     graph_url: ''
     output_format:
+    edge_merging_attributes:
+      - taxon
     sources:
       - source_id: GtoPdb
     subgraphs:

--- a/tests/test_ctd_loader.py
+++ b/tests/test_ctd_loader.py
@@ -1,0 +1,50 @@
+import io
+import tarfile
+
+from orion.biolink_constants import TAXON
+from orion.prefixes import NCBITAXON
+from parsers.CTD.src.loadCTD import CTDLoader
+
+
+class CapturingWriter:
+    def __init__(self):
+        self.nodes = []
+        self.edges = []
+
+    def write_kgx_node(self, node):
+        self.nodes.append(node)
+
+    def write_kgx_edge(self, edge):
+        self.edges.append(edge)
+
+
+def test_chemical_gene_taxon_is_edge_context_not_node_property(tmp_path):
+    ctd_row = '\t'.join([
+        'MESH:C000',
+        'test chemical',
+        'increases expression of',
+        '->',
+        'NCBIGene:1',
+        'test gene',
+        'protein',
+        'NCBITaxon:9606',
+        'PMID:1|PMID:2|PMID:3',
+    ])
+    archive_path = tmp_path / 'ctd.tar.gz'
+    file_bytes = f'header ignored by parser\n{ctd_row}\n'.encode()
+    tar_info = tarfile.TarInfo('ctd-grouped-pipes.tsv')
+    tar_info.size = len(file_bytes)
+    with tarfile.open(archive_path, 'w:gz') as archive:
+        archive.addfile(tar_info, io.BytesIO(file_bytes))
+
+    loader = CTDLoader(test_mode=True, source_data_dir=str(tmp_path))
+    loader.output_file_writer = CapturingWriter()
+
+    loader.chemical_to_gene_exp(str(archive_path), 'ctd-grouped-pipes.tsv')
+
+    gene_node = next(node for node in loader.output_file_writer.nodes if node.identifier == 'NCBIGENE:1')
+    assert NCBITAXON not in gene_node.properties
+
+    assert len(loader.output_file_writer.edges) == 1
+    edge = loader.output_file_writer.edges[0]
+    assert edge.properties[TAXON] == 'NCBITaxon:9606'

--- a/tests/test_kgx_file_normalizer.py
+++ b/tests/test_kgx_file_normalizer.py
@@ -4,7 +4,7 @@ from urllib.parse import parse_qs, urlparse
 import jsonlines
 import pytest
 
-from orion.biolink_constants import NAMED_THING, GENE, NODE_TYPES, SUBJECT_ID, OBJECT_ID, PREDICATE
+from orion.biolink_constants import NAMED_THING, GENE, NODE_TYPES, SUBJECT_ID, OBJECT_ID, PREDICATE, TAXON
 from orion.kgx_file_normalizer import KGXFileNormalizer
 
 
@@ -36,6 +36,7 @@ NODE_NORM_RESPONSE = {
             {'identifier': 'OMIM:172460'},
             {'identifier': 'UMLS:C1417420', 'label': 'MTHFD1 gene'},
         ],
+        'taxa': ['NCBITaxon:9606'],
         'information_content': 84.8,
     },
     'CHEBI:33551': {
@@ -160,6 +161,10 @@ def test_kgx_file_normalizer_basic(tmp_path, mock_normalization):
     assert output_edges[0][PREDICATE] == 'biolink:causes'
     assert output_edges[0][SUBJECT_ID] == 'NCBIGene:4522'
     assert output_edges[0][OBJECT_ID] == 'CHEBI:33551'
+
+    output_nodes = list(jsonlines.open(paths['nodes_output_file_path']))
+    output_gene = next(node for node in output_nodes if node['id'] == 'NCBIGene:4522')
+    assert output_gene[TAXON] == 'NCBITaxon:9606'
 
     assert os.path.exists(paths['edge_norm_predicate_map_file_path'])
     assert mock_normalization['edge_norm_calls'], 'expected at least one bl_lookup call'

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -57,6 +57,31 @@ def test_node_norm(test_nodes):
     assert get_node_from_list('ENSEMBL:testing_id', test_nodes) is None
 
 
+def test_node_norm_adds_top_level_taxa(monkeypatch):
+    node_norm_response = {
+        'HGNC:7432': {
+            'id': {'identifier': 'NCBIGene:4522', 'label': 'MTHFD1'},
+            'type': [GENE, NAMED_THING],
+            'equivalent_identifiers': [{'identifier': 'NCBIGene:4522', 'label': 'MTHFD1'}],
+            'taxa': ['NCBITaxon:9606'],
+        },
+    }
+
+    def fake_hit_node_norm(self, curies, retries=0):
+        return {curie: node_norm_response.get(curie) for curie in curies}
+
+    monkeypatch.setattr(NodeNormalizer, 'hit_node_norm_service', fake_hit_node_norm)
+
+    nodes = [{"id": "HGNC:7432", "name": "MTHFD1", NODE_TYPES: [GENE]}]
+    node_normalizer = NodeNormalizer()
+    assert node_normalizer.include_taxa is True
+
+    node_normalizer.normalize_node_data(nodes)
+
+    normalized_node = get_node_from_list('NCBIGene:4522', nodes)
+    assert normalized_node[TAXON] == 'NCBITaxon:9606'
+
+
 def test_node_norm_lenient(test_nodes):
     node_normalizer = NodeNormalizer(strict_normalization=False)
     node_normalizer.normalize_node_data(test_nodes)


### PR DESCRIPTION
## Summary
- Enable Babel taxon retrieval during normalization and use the top-level NodeNorm `taxa` field for node `taxon`.
- Remove CTD gene node `NCBITaxon` properties and emit CTD row-level taxa as edge `taxon` CURIEs.
- Preserve CTD row-level taxa during graph merges by adding `edge_merging_attributes: [taxon]` to CTD-containing graph specs and downstream subgraph merge specs.

## Validation
- `uv run --with beautifulsoup4 pytest tests/test_graph_spec.py tests/test_merging.py tests/test_normalization.py tests/test_kgx_file_normalizer.py tests/test_ctd_loader.py` -> `70 passed`.
- Rebuilt CTD KGX graph with taxon-aware merging: build status `stable`, QC passed, 26,491 nodes, 186,376 edges.
- Rebuilt CTD output has 10,659 node `taxon` properties, 83,806 edge `taxon` properties, zero `NCBITaxon`/`taxonid` node or edge properties, and zero invalid taxon CURIE values.
- Taxon-aware merge check found zero source merge groups with multiple distinct taxa.

## Notes
- A local Neo4j-output build reached KGX build and QC but failed afterward because `neo4j-admin` is not installed locally; KGX validation completed successfully.