### PR TITLE
Create a ROBOKOP + Mouse graph.

### DIFF
--- a/graph_specs/cfde-graph-spec.yaml
+++ b/graph_specs/cfde-graph-spec.yaml
@@ -16,6 +16,7 @@ graphs:
       - source_id: HGNC
       - source_id: HMDB
       - source_id: HumanGOA
+      - source_id: MouseGOA
       - source_id: IntAct
       - source_id: KinAce
       - source_id: LINCS
@@ -35,4 +36,3 @@ graphs:
       - source_id: UbergraphNonredundant
       - source_id: GWASCatalog
       - source_id: GTEx
-

--- a/graph_specs/default-graph-spec.yml
+++ b/graph_specs/default-graph-spec.yml
@@ -35,6 +35,7 @@ graphs:
       - source_id: HGNC
       - source_id: HMDB
       - source_id: HumanGOA
+      - source_id: MouseGOA
       - source_id: IntAct
       - source_id: KinAce
       - source_id: LINCS
@@ -212,6 +213,16 @@ graphs:
       - source_id: OntologicalHierarchy
         merge_strategy: connected_edge_subset
 
+  - graph_id: MouseGOA_Automat
+    graph_name: Mouse GOA
+    graph_description: 'The Gene Ontology (GO) Consortium’s mouse annotation resource provides open access to curated assignment of GO terms to mouse gene products.'
+    graph_url: https://geneontology.org/
+    output_format: neo4j
+    sources:
+      - source_id: MouseGOA
+      - source_id: OntologicalHierarchy
+        merge_strategy: connected_edge_subset
+
   - graph_id: IntAct_Automat
     graph_name: IntAct Molecular Interaction Database
     graph_description: 'The IntAct Molecular Interaction Database provides open access to molecular interactions data derived from literature curation or direct user submission.'
@@ -298,4 +309,3 @@ graphs:
       - source_id: ViralProteome
       - source_id: OntologicalHierarchy
         merge_strategy: connected_edge_subset
-

--- a/graph_specs/default-graph-spec.yml
+++ b/graph_specs/default-graph-spec.yml
@@ -35,7 +35,6 @@ graphs:
       - source_id: HGNC
       - source_id: HMDB
       - source_id: HumanGOA
-      - source_id: MouseGOA
       - source_id: IntAct
       - source_id: KinAce
       - source_id: LINCS
@@ -64,6 +63,20 @@ graphs:
       - source_id: ClinGenVariantPathogenicity
       - source_id: GWASCatalog
       - source_id: GTEx
+
+  - graph_id: RoboMouseKG
+    graph_name: RoboMouse KG
+    graph_description: 'RoboMouse KG extends ROBOKOP KG with mouse Gene Ontology annotations and Alliance of Genome Resources orthology relationships.'
+    graph_url: http://robokopkg.renci.org/browser/
+    conflation: True
+    output_format: neo4j
+    subgraphs:
+      - graph_id: RobokopKG
+    sources:
+      - source_id: MouseGOA
+      - source_id: GenomeAllianceOrthologs
+      - source_id: OntologicalHierarchy
+        merge_strategy: connected_edge_subset
 
   - graph_id: BINDING_Automat
     graph_name: BINDING

--- a/graph_specs/matrix-graph-spec.yaml
+++ b/graph_specs/matrix-graph-spec.yaml
@@ -19,6 +19,7 @@ graphs:
       - source_id: HGNC
       - source_id: HMDB
       - source_id: HumanGOA
+      - source_id: MouseGOA
       - source_id: IntAct
       - source_id: KinAce
       - source_id: LINCS

--- a/graph_specs/matrix-graph-spec.yaml
+++ b/graph_specs/matrix-graph-spec.yaml
@@ -19,7 +19,6 @@ graphs:
       - source_id: HGNC
       - source_id: HMDB
       - source_id: HumanGOA
-      - source_id: MouseGOA
       - source_id: IntAct
       - source_id: KinAce
       - source_id: LINCS

--- a/graph_specs/rule-mining-graph-spec.yaml
+++ b/graph_specs/rule-mining-graph-spec.yaml
@@ -18,6 +18,7 @@ graphs:
       - source_id: HGNC
       - source_id: HMDB
       - source_id: HumanGOA
+      - source_id: MouseGOA
       - source_id: IntAct
       - source_id: MonarchKG
       - source_id: MONDOProps

--- a/graph_specs/yeast-graph-spec.yml
+++ b/graph_specs/yeast-graph-spec.yml
@@ -32,6 +32,7 @@ graphs:
       - source_id: HGNC
       - source_id: HMDB
       - source_id: HumanGOA
+      - source_id: MouseGOA
       - source_id: IntAct
       - source_id: MonarchKG
       - source_id: MONDOProps

--- a/orion/data_sources.py
+++ b/orion/data_sources.py
@@ -26,6 +26,7 @@ HETIO = 'Hetio'
 HGNC = 'HGNC'
 HMDB = 'HMDB'
 HUMAN_GOA = 'HumanGOA'
+MOUSE_GOA = 'MouseGOA'
 INTACT = 'IntAct'
 LINCS = 'LINCS'
 LITCOIN = 'LitCoin'
@@ -84,6 +85,7 @@ SOURCE_DATA_LOADER_CLASS_IMPORTS = {
     HGNC: ("parsers.hgnc.src.loadHGNC", "HGNCLoader"),
     HMDB: ("parsers.hmdb.src.loadHMDB", "HMDBLoader"),
     HUMAN_GOA: ("parsers.GOA.src.loadGOA", "HumanGOALoader"),
+    MOUSE_GOA: ("parsers.GOA.src.loadGOA", "MouseGOALoader"),
     HUMAN_STRING: ("parsers.STRING.src.loadSTRINGDB", "HumanSTRINGDBLoader"),
     INTACT: ("parsers.IntAct.src.loadIA", "IALoader"),
     LINCS: ("parsers.LINCS.src.loadLINCS", "LINCSLoader"),
@@ -169,4 +171,3 @@ def get_data_loader_class(key):
 class SourceDataLoaderClassFactory(KeyBasedDefaultDict):
     def __init__(self):
         super(KeyBasedDefaultDict, self).__init__(get_data_loader_class)
-

--- a/parsers/ClinGenDosageSensitivity/src/loadClinGenDosageSensitivity.py
+++ b/parsers/ClinGenDosageSensitivity/src/loadClinGenDosageSensitivity.py
@@ -5,6 +5,7 @@ from orion.biolink_constants import PRIMARY_KNOWLEDGE_SOURCE, NODE_TYPES, SEQUEN
 from orion.utils import GetData
 from datetime import date
 import csv
+from typing import Callable
 
 
 # Constants for data processing

--- a/parsers/GOA/src/MouseGOA.source.json
+++ b/parsers/GOA/src/MouseGOA.source.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "identifier": "infores:goa",
+  "name": "Gene Ontology Annotations (Mouse)",
+  "description": "The Gene Ontology (GO) Consortium's mouse annotation resource provides open access to curated assignment of GO terms to mouse gene products.",
+  "url": "https://geneontology.org/",
+  "attribution": "https://geneontology.org/",
+  "citation": [
+    "https://doi.org/10.1093/genetics/iyad031",
+    "The Gene Ontology Consortium. The Gene Ontology knowledgebase in 2023. Genetics. 2023 May 4;224(1):iyad031."
+  ],
+  "license": "CC BY 4.0",
+  "contentUrl": "http://current.geneontology.org/annotations/mgi.gaf.gz"
+}

--- a/parsers/GOA/src/loadGOA.py
+++ b/parsers/GOA/src/loadGOA.py
@@ -163,7 +163,7 @@ class GOALoader(SourceDataLoader):
         extractor = Extractor()
         with (gzip.open if infile_path.endswith(".gz") else open)(infile_path) as zf:
             extractor.csv_extract(TextIOWrapper(zf, "utf-8"),
-                                  lambda line: f'{line[DATACOLS.DB.value]}:{line[DATACOLS.DB_Object_ID.value]}',
+                                  lambda line: get_goa_subject_id(line),
                                   # extract subject id,
                                   lambda line: f'{line[DATACOLS.GO_ID.value]}',  # extract object id
                                   lambda line: get_goa_predicate(line),  # predicate extractor
@@ -177,6 +177,12 @@ class GOALoader(SourceDataLoader):
         self.final_node_list = extractor.nodes
         self.final_edge_list = extractor.edges
         return extractor.load_metadata
+
+
+def get_goa_subject_id(line: list):
+    db = line[DATACOLS.DB.value]
+    db_object_id = line[DATACOLS.DB_Object_ID.value]
+    return db_object_id if ':' in db_object_id else f'{db}:{db_object_id}'
 
 
 def get_goa_edge_properties(line: list):
@@ -229,6 +235,22 @@ class HumanGOALoader(GOALoader):
         super().__init__(test_mode=test_mode, source_data_dir=source_data_dir)
         self.goa_data_url = 'http://current.geneontology.org/annotations/'
         self.goa_data_file = 'goa_human.gaf.gz'
+        self.data_files = [self.goa_data_file]
+        self.data_urls = [self.goa_data_url]
+        self.taxon_filter_field = None
+
+    def get_taxon_filter_set(self):
+        return None
+
+
+class MouseGOALoader(GOALoader):
+
+    source_id = 'MouseGOA'
+
+    def __init__(self, test_mode: bool = False, source_data_dir: str = None):
+        super().__init__(test_mode=test_mode, source_data_dir=source_data_dir)
+        self.goa_data_url = 'http://current.geneontology.org/annotations/'
+        self.goa_data_file = 'mgi.gaf.gz'
         self.data_files = [self.goa_data_file]
         self.data_urls = [self.goa_data_url]
         self.taxon_filter_field = None

--- a/parsers/ViralProteome/src/loadVP.py
+++ b/parsers/ViralProteome/src/loadVP.py
@@ -7,7 +7,8 @@ from csv import reader
 from orion.utils import GetData
 from orion.extractor import Extractor
 from orion.loader_interface import SourceDataLoader
-from parsers.GOA.src.loadGOA import get_goa_predicate, get_goa_edge_properties, get_goa_subject_props, DATACOLS
+from parsers.GOA.src.loadGOA import (get_goa_subject_id, get_goa_predicate, get_goa_edge_properties,
+                                     get_goa_subject_props, DATACOLS)
 
 
 ##############
@@ -149,7 +150,7 @@ class VPLoader(SourceDataLoader):
             file_count += 1
             with open(os.path.join(self.data_path, f), 'r', encoding="utf-8") as fp:
                 extractor.csv_extract(fp,
-                                      lambda line: f'{line[DATACOLS.DB.value]}:{line[DATACOLS.DB_Object_ID.value]}',
+                                      lambda line: get_goa_subject_id(line),
                                       # extract subject id,
                                       lambda line: f'{line[DATACOLS.GO_ID.value]}',  # extract object id
                                       lambda line: get_goa_predicate(line),  # predicate extractor

--- a/tests/test_goa_loader.py
+++ b/tests/test_goa_loader.py
@@ -1,0 +1,83 @@
+import gzip
+import json
+from pathlib import Path
+
+from parsers.GOA.src.loadGOA import DATACOLS, MouseGOALoader, get_goa_subject_id
+
+
+def make_gaf_row(**overrides):
+    row = [
+        "UniProtKB",
+        "P12345",
+        "GENE1",
+        "enables",
+        "GO:0003674",
+        "PMID:1",
+        "IDA",
+        "",
+        "F",
+        "gene product 1",
+        "",
+        "protein",
+        "taxon:9606",
+        "20260101",
+        "UniProt",
+        "",
+        "",
+    ]
+    for column, value in overrides.items():
+        row[DATACOLS[column].value] = value
+    return row
+
+
+def test_goa_subject_id_preserves_prefixed_ids():
+    row = make_gaf_row(DB="MGI", DB_Object_ID="MGI:101757")
+
+    assert get_goa_subject_id(row) == "MGI:101757"
+
+
+def test_goa_subject_id_prefixes_unprefixed_ids():
+    row = make_gaf_row(DB="UniProtKB", DB_Object_ID="P12345")
+
+    assert get_goa_subject_id(row) == "UniProtKB:P12345"
+
+
+def test_mouse_goa_loader_uses_mgi_ids_and_mouse_taxon(tmp_path):
+    loader = MouseGOALoader(source_data_dir=str(tmp_path))
+    data_path = Path(loader.data_path)
+    gaf_path = data_path / loader.goa_data_file
+    row = make_gaf_row(
+        DB="MGI",
+        DB_Object_ID="MGI:101757",
+        DB_Object_Symbol="Cfl1",
+        GO_ID="GO:0000281",
+        Taxon_Interacting_taxon="taxon:10090",
+        Gene_Product_Form_ID="MGI:MGI:101757",
+    )
+    with gzip.open(gaf_path, "wt", encoding="utf-8") as gaf:
+        gaf.write("!gaf-version: 2.2\n")
+        gaf.write("\t".join(row) + "\n")
+
+    nodes_path = tmp_path / "nodes.jsonl"
+    edges_path = tmp_path / "edges.jsonl"
+    metadata = loader.load(str(nodes_path), str(edges_path))
+
+    nodes = [json.loads(line) for line in nodes_path.read_text().splitlines()]
+    edges = [json.loads(line) for line in edges_path.read_text().splitlines()]
+    nodes_by_id = {node["id"]: node for node in nodes}
+
+    assert metadata["source_edges"] == 1
+    assert "MGI:101757" in nodes_by_id
+    assert "MGI:MGI:101757" not in nodes_by_id
+    assert nodes_by_id["MGI:101757"]["taxon"] == "NCBITaxon:10090"
+    assert edges == [
+        {
+            "subject": "MGI:101757",
+            "predicate": "RO:0002327",
+            "object": "GO:0000281",
+            "primary_knowledge_source": "infores:goa",
+            "knowledge_level": "knowledge_assertion",
+            "agent_type": "manual_agent",
+            "publications": ["PMID:1"],
+        }
+    ]

--- a/tests/test_graph_spec.py
+++ b/tests/test_graph_spec.py
@@ -74,6 +74,28 @@ def test_valid_graph_spec_config(test_graph_spec_dir, test_graph_output_dir):
         assert source.source_version is None
 
 
+def test_default_graph_spec_defines_robomouse(monkeypatch, test_graph_output_dir):
+    default_specs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'graph_specs')
+    set_config(ORION_GRAPH_SPEC='default-graph-spec.yml', ORION_GRAPH_SPEC_URL='')
+    monkeypatch.setattr('orion.ingest_pipeline.IngestPipeline.get_latest_edge_normalization_version',
+                        lambda self: 'test-edge-normalization')
+
+    graph_builder = GraphBuilder(graph_specs_dir=default_specs_dir,
+                                 graph_output_dir=test_graph_output_dir)
+
+    baseline_sources = [source.id for source in graph_builder.graph_specs['Baseline'].sources]
+    assert 'HumanGOA' in baseline_sources
+    assert 'MouseGOA' not in baseline_sources
+
+    robomouse_graph = graph_builder.graph_specs['RoboMouseKG']
+    assert [subgraph.id for subgraph in robomouse_graph.subgraphs] == ['RobokopKG']
+    assert [source.id for source in robomouse_graph.sources] == [
+        'MouseGOA',
+        'GenomeAllianceOrthologs',
+        'OntologicalHierarchy',
+    ]
+
+
 # graph spec sources are able to return versions once source_version(s) are set
 def test_graph_spec_lazy_versions(test_graph_spec_dir, test_graph_output_dir):
     reset_graph_spec_config()


### PR DESCRIPTION
## Summary
- Add a `MouseGOA` source backed by the current GO annotation `mgi.gaf.gz` file.
- Preserve already-prefixed GOA subject IDs so MGI rows use `MGI:101757` instead of `MGI:MGI:101757`.
- Keep `MouseGOA` out of the standard ROBOKOP `Baseline` graph and add a `RoboMouseKG` graph that layers `MouseGOA`, `GenomeAllianceOrthologs`, and connected ontology hierarchy on top of `RobokopKG`.
- Add a standalone `MouseGOA_Automat` graph.
- Reuse the GOA subject-ID helper in ViralProteome parsing for consistent GAF ID handling.
- Fix the `ClinGenDosageSensitivity` `Callable` import so the default graph spec can be loaded in validation.

## Validation
- `uv run pytest tests/test_goa_loader.py tests/test_graph_spec.py tests/test_normalization.py tests/test_kgx_file_normalizer.py` -> `22 passed`.
- Parsed `default-graph-spec.yml` and confirmed `Baseline` excludes `MouseGOA`, while `RoboMouseKG` has subgraph `RobokopKG` plus sources `MouseGOA`, `GenomeAllianceOrthologs`, and `OntologicalHierarchy`.
- `ORION_STORAGE=/tmp/orion-mousegoa-storage ORION_LOGS=/tmp/orion-mousegoa-logs uv run --extra robokop orion-ingest MouseGOA` completed successfully and generated release `430e1d5038a7c60a`.
- MouseGOA ingest QC passed with 46,161 normalized nodes and 706,457 normalized edges.
- Normalized MouseGOA output has 25,807 `NCBIGene` nodes, 27,154 nodes with `taxon: NCBITaxon:10090`, and zero `MGI:MGI:` double-prefixed nodes.
- `ORION_STORAGE=/tmp/orion-humangoa-storage ORION_LOGS=/tmp/orion-humangoa-logs uv run --extra robokop orion-ingest HumanGOA` completed successfully and generated release `fb21613635882873`.