### PR TITLE
Remove Monarch from Baseline

### DIFF
--- a/graph_specs/default-graph-spec.yml
+++ b/graph_specs/default-graph-spec.yml
@@ -41,7 +41,6 @@ graphs:
       - source_id: KinAce
       - source_id: LINCS
       - source_id: MetabolomicsWorkbench
-      - source_id: MonarchKG
       - source_id: MONDOProps
       - source_id: OntologicalHierarchy
         merge_strategy: connected_edge_subset

--- a/tests/test_graph_spec.py
+++ b/tests/test_graph_spec.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import requests.exceptions
+import yaml
 
 from unittest.mock import MagicMock
 from orion.build_manager import GraphBuilder, GraphSpecError
@@ -85,6 +86,7 @@ def test_default_graph_spec_defines_robomouse(monkeypatch, test_graph_output_dir
 
     baseline_sources = [source.id for source in graph_builder.graph_specs['Baseline'].sources]
     assert 'HumanGOA' in baseline_sources
+    assert 'MonarchKG' not in baseline_sources
     assert 'MouseGOA' not in baseline_sources
 
     robomouse_graph = graph_builder.graph_specs['RoboMouseKG']
@@ -94,6 +96,24 @@ def test_default_graph_spec_defines_robomouse(monkeypatch, test_graph_output_dir
         'GenomeAllianceOrthologs',
         'OntologicalHierarchy',
     ]
+
+
+def test_default_baseline_does_not_include_monarchkg():
+    default_graph_spec_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        '..',
+        'graph_specs',
+        'default-graph-spec.yml',
+    )
+    with open(default_graph_spec_path) as graph_spec_file:
+        graph_spec = yaml.safe_load(graph_spec_file)
+
+    baseline_graph = next(graph for graph in graph_spec['graphs'] if graph['graph_id'] == 'Baseline')
+    baseline_sources = [source['source_id'] for source in baseline_graph['sources']]
+
+    assert 'HumanGOA' in baseline_sources
+    assert 'MonarchKG' not in baseline_sources
+    assert 'UbergraphNonredundant' in baseline_sources
 
 
 # graph spec sources are able to return versions once source_version(s) are set


### PR DESCRIPTION
## Summary
- Remove `MonarchKG` from the default `Baseline` graph source list.
- Keep `MonarchKG` and `MonarchKGFull` source registrations intact.
- Leave standalone and special graph specs that explicitly include `MonarchKG` unchanged.
- Add graph-spec checks that default `Baseline` excludes `MonarchKG` while retaining direct replacement sources such as `HumanGOA` and `UbergraphNonredundant`.

## Do Not Merge Yet
Do not merge this PR until #416, #417, #418, and #419 are merged.

Those PRs move the major Monarch-mediated source families into direct ingests or more appropriate existing ingests. This PR should be the final switch that removes Monarch from the default Baseline after those replacements are in place.

## Tests
- `uv run pytest tests/test_graph_spec.py::test_default_baseline_does_not_include_monarchkg`

## Local Validation Note
- `uv run pytest tests/test_graph_spec.py::test_default_graph_spec_defines_robomouse` is currently blocked in this local venv by an unrelated `pyoxigraph` import mismatch: `ImportError: cannot import name 'RdfFormat' from 'pyoxigraph'`.
